### PR TITLE
feat: 카카오 소셜 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,9 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	// redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,17 @@ dependencies {
 
 	// swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
+
+	// security
+	testImplementation 'org.springframework.security:spring-security-test'
+
+	// oauth
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+	// jwt
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/cheeeese/CheeeeseApplication.java
+++ b/src/main/java/com/cheeeese/CheeeeseApplication.java
@@ -3,9 +3,11 @@ package com.cheeeese;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableRedisRepositories(basePackages = "com.cheeeese.oauth2.infrastructure.persistence")
 public class CheeeeseApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/cheeeese/auth/application/AuthService.java
+++ b/src/main/java/com/cheeeese/auth/application/AuthService.java
@@ -4,11 +4,11 @@ import com.cheeeese.auth.dto.response.TempCodeExchangeResponse;
 import com.cheeeese.auth.exception.AuthException;
 import com.cheeeese.auth.exception.code.AuthErrorCode;
 import com.cheeeese.auth.infrastructure.mapper.AuthMapper;
-import com.cheeeese.global.common.code.ErrorCode;
-import com.cheeeese.global.exception.BusinessException;
 import com.cheeeese.global.security.jwt.JwtProvider;
 import com.cheeeese.global.util.RedisUtil;
 import com.cheeeese.user.domain.User;
+import com.cheeeese.user.exception.UserException;
+import com.cheeeese.user.exception.code.UserErrorCode;
 import com.cheeeese.user.infrastructure.persistence.UserRepository;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -48,7 +48,7 @@ public class AuthService {
             String userId = claims.getSubject();
 
             User user = userRepository.findById(Long.valueOf(userId))
-                    .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+                    .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
 
             redisUtil.deleteValue(key);
 

--- a/src/main/java/com/cheeeese/auth/application/AuthService.java
+++ b/src/main/java/com/cheeeese/auth/application/AuthService.java
@@ -1,0 +1,61 @@
+package com.cheeeese.auth.application;
+
+import com.cheeeese.auth.dto.response.TempCodeExchangeResponse;
+import com.cheeeese.auth.exception.AuthException;
+import com.cheeeese.auth.exception.code.AuthErrorCode;
+import com.cheeeese.auth.infrastructure.mapper.AuthMapper;
+import com.cheeeese.global.common.code.ErrorCode;
+import com.cheeeese.global.exception.BusinessException;
+import com.cheeeese.global.security.jwt.JwtProvider;
+import com.cheeeese.global.util.RedisUtil;
+import com.cheeeese.user.domain.User;
+import com.cheeeese.user.infrastructure.persistence.UserRepository;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AuthService {
+
+    private final JwtProvider jwtProvider;
+    private final UserRepository userRepository;
+    private final ObjectMapper objectMapper;
+    private final RedisUtil redisUtil;
+
+    public TempCodeExchangeResponse exchangeTempCode(String code) {
+        String key = "auth:" + code;
+        String json = redisUtil.getValue(key);
+
+        if (json == null) {
+            throw new AuthException(AuthErrorCode.INVALID_AUTH_CODE);
+        }
+
+        try {
+            Map<String, String> data = objectMapper.readValue(json, new TypeReference<>() {});
+
+            String accessToken = data.get("accessToken");
+            String refreshToken = data.get("refreshToken");
+
+            Claims claims = jwtProvider.getClaims(accessToken);
+            String userId = claims.getSubject();
+
+            User user = userRepository.findById(Long.valueOf(userId))
+                    .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+            redisUtil.deleteValue(key);
+
+            return AuthMapper.toResponse(accessToken, refreshToken, user);
+        } catch (JsonProcessingException e) {
+            redisUtil.deleteValue(key);
+            throw new AuthException(AuthErrorCode.TOKEN_PARSE_FAILED);
+        }
+    }
+}

--- a/src/main/java/com/cheeeese/auth/application/AuthService.java
+++ b/src/main/java/com/cheeeese/auth/application/AuthService.java
@@ -31,6 +31,15 @@ public class AuthService {
     private final RedisUtil redisUtil;
 
     public TempCodeExchangeResponse exchangeTempCode(String code) {
+        Map<String, String> tokens = getTokenFromTempCode(code);
+        User user = getUserFromToken(tokens.get("accessToken"));
+
+        redisUtil.deleteValue("auth:" + code);
+
+        return AuthMapper.toResponse(tokens.get("accessToken"), tokens.get("refreshToken"), user);
+    }
+
+    private Map<String, String> getTokenFromTempCode(String code) {
         String key = "auth:" + code;
         String json = redisUtil.getValue(key);
 
@@ -39,23 +48,17 @@ public class AuthService {
         }
 
         try {
-            Map<String, String> data = objectMapper.readValue(json, new TypeReference<>() {});
-
-            String accessToken = data.get("accessToken");
-            String refreshToken = data.get("refreshToken");
-
-            Claims claims = jwtProvider.getClaims(accessToken);
-            String userId = claims.getSubject();
-
-            User user = userRepository.findById(Long.valueOf(userId))
-                    .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
-
-            redisUtil.deleteValue(key);
-
-            return AuthMapper.toResponse(accessToken, refreshToken, user);
+            return objectMapper.readValue(json, new TypeReference<>() {});
         } catch (JsonProcessingException e) {
-            redisUtil.deleteValue(key);
             throw new AuthException(AuthErrorCode.TOKEN_PARSE_FAILED);
         }
+    }
+
+    private User getUserFromToken(String accessToken) {
+        Claims claims = jwtProvider.getClaims(accessToken);
+        String userId = claims.getSubject();
+
+        return userRepository.findById(Long.valueOf(userId))
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/cheeeese/auth/dto/response/TempCodeExchangeResponse.java
+++ b/src/main/java/com/cheeeese/auth/dto/response/TempCodeExchangeResponse.java
@@ -1,0 +1,13 @@
+package com.cheeeese.auth.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record TempCodeExchangeResponse(
+        String accessToken,
+        String refreshToken,
+        Long userId,
+        String name,
+        String email
+) {
+}

--- a/src/main/java/com/cheeeese/auth/exception/AuthException.java
+++ b/src/main/java/com/cheeeese/auth/exception/AuthException.java
@@ -1,0 +1,12 @@
+package com.cheeeese.auth.exception;
+
+import com.cheeeese.auth.exception.code.AuthErrorCode;
+import com.cheeeese.global.exception.BusinessException;
+import lombok.Getter;
+
+@Getter
+public class AuthException extends BusinessException {
+    public AuthException(AuthErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/cheeeese/auth/exception/code/AuthErrorCode.java
+++ b/src/main/java/com/cheeeese/auth/exception/code/AuthErrorCode.java
@@ -12,6 +12,7 @@ public enum AuthErrorCode implements BaseCode {
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
     TOKEN_PARSE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "토큰 파싱에 실패했습니다."),
     INVALID_AUTH_CODE(HttpStatus.BAD_REQUEST, "유효하지 않은 인증 코드 입니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/cheeeese/auth/exception/code/AuthErrorCode.java
+++ b/src/main/java/com/cheeeese/auth/exception/code/AuthErrorCode.java
@@ -1,0 +1,19 @@
+package com.cheeeese.auth.exception.code;
+
+import com.cheeeese.global.common.code.BaseCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum AuthErrorCode implements BaseCode {
+
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+    TOKEN_PARSE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "토큰 파싱에 실패했습니다."),
+    INVALID_AUTH_CODE(HttpStatus.BAD_REQUEST, "유효하지 않은 인증 코드 입니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/cheeeese/auth/infrastructure/mapper/AuthMapper.java
+++ b/src/main/java/com/cheeeese/auth/infrastructure/mapper/AuthMapper.java
@@ -1,0 +1,17 @@
+package com.cheeeese.auth.infrastructure.mapper;
+
+import com.cheeeese.auth.dto.response.TempCodeExchangeResponse;
+import com.cheeeese.user.domain.User;
+
+public class AuthMapper {
+
+    public static TempCodeExchangeResponse toResponse(String accessToken, String refreshToken, User user) {
+        return TempCodeExchangeResponse.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .userId(user.getId())
+                .name(user.getName())
+                .email(user.getEmail())
+                .build();
+    }
+}

--- a/src/main/java/com/cheeeese/auth/presentation/AuthController.java
+++ b/src/main/java/com/cheeeese/auth/presentation/AuthController.java
@@ -1,0 +1,27 @@
+package com.cheeeese.auth.presentation;
+
+import com.cheeeese.auth.application.AuthService;
+import com.cheeeese.auth.dto.response.TempCodeExchangeResponse;
+import com.cheeeese.auth.presentation.swagger.AuthSwagger;
+import com.cheeeese.global.common.CommonResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.cheeeese.global.common.code.SuccessCode.EXCHANGE_TOKEN_SUCCESS;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/auth")
+public class AuthController implements AuthSwagger {
+
+    private final AuthService authService;
+
+    @Override
+    @GetMapping("/exchange")
+    public CommonResponse<TempCodeExchangeResponse> exchangeTempCode(@RequestParam String code) {
+        return CommonResponse.success(EXCHANGE_TOKEN_SUCCESS, authService.exchangeTempCode(code));
+    }
+}

--- a/src/main/java/com/cheeeese/auth/presentation/swagger/AuthSwagger.java
+++ b/src/main/java/com/cheeeese/auth/presentation/swagger/AuthSwagger.java
@@ -1,0 +1,26 @@
+package com.cheeeese.auth.presentation.swagger;
+
+import com.cheeeese.auth.dto.response.TempCodeExchangeResponse;
+import com.cheeeese.global.common.CommonResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "[사용자 인증/인가]", description = "사용자 로그아웃, 토큰 재발급 관련 API")
+public interface AuthSwagger {
+    @Operation(
+            summary = "사용자 토큰 및 정보 조회 API",
+            description = "발급된 임시 코드를 통해 사용자의 accessToken, refreshToken 및 정보를 반환합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "사용자 토큰 및 정보 조회가 성공적으로 실행되었습니다."
+            )
+    })
+    CommonResponse<TempCodeExchangeResponse> exchangeTempCode(
+            @RequestParam String code
+    );
+}

--- a/src/main/java/com/cheeeese/global/common/code/ErrorCode.java
+++ b/src/main/java/com/cheeeese/global/common/code/ErrorCode.java
@@ -13,10 +13,6 @@ public enum ErrorCode implements BaseCode {
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
     FORBIDDEN(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
-
-    // TODO: 패키지 이동
-    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/cheeeese/global/common/code/ErrorCode.java
+++ b/src/main/java/com/cheeeese/global/common/code/ErrorCode.java
@@ -13,6 +13,10 @@ public enum ErrorCode implements BaseCode {
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
     FORBIDDEN(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
+
+    // TODO: 패키지 이동
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/cheeeese/global/common/code/SuccessCode.java
+++ b/src/main/java/com/cheeeese/global/common/code/SuccessCode.java
@@ -10,6 +10,9 @@ public enum SuccessCode implements BaseCode{
 
     // health_check
     HEALTH_CHECK_SUCCESS(HttpStatus.OK, "Health Check Success"),
+
+    // auth
+    EXCHANGE_TOKEN_SUCCESS(HttpStatus.OK, "Exchange Token Success"),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/cheeeese/global/common/code/SuccessCode.java
+++ b/src/main/java/com/cheeeese/global/common/code/SuccessCode.java
@@ -6,7 +6,7 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
-public enum SuccessCode implements BaseCode{
+public enum SuccessCode implements BaseCode {
 
     // health_check
     HEALTH_CHECK_SUCCESS(HttpStatus.OK, "Health Check Success"),

--- a/src/main/java/com/cheeeese/global/config/ConfigurationPropertiesConfig.java
+++ b/src/main/java/com/cheeeese/global/config/ConfigurationPropertiesConfig.java
@@ -1,0 +1,10 @@
+package com.cheeeese.global.config;
+
+import com.cheeeese.global.security.jwt.JwtProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(value = JwtProperties.class)
+public class ConfigurationPropertiesConfig {
+}

--- a/src/main/java/com/cheeeese/global/config/RedisConfig.java
+++ b/src/main/java/com/cheeeese/global/config/RedisConfig.java
@@ -1,0 +1,43 @@
+package com.cheeeese.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Value("${spring.data.redis.password}")
+    private String password;
+
+    @Bean
+    public LettuceConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(host, port);
+        config.setPassword(password);
+
+        return new LettuceConnectionFactory(config);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/cheeeese/global/config/SecurityConfig.java
+++ b/src/main/java/com/cheeeese/global/config/SecurityConfig.java
@@ -14,7 +14,6 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestRedirectFilter;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 

--- a/src/main/java/com/cheeeese/global/config/SecurityConfig.java
+++ b/src/main/java/com/cheeeese/global/config/SecurityConfig.java
@@ -1,0 +1,64 @@
+package com.cheeeese.global.config;
+
+import com.cheeeese.global.security.handler.JwtAccessDeniedHandler;
+import com.cheeeese.global.security.handler.JwtAuthenticationEntryPoint;
+import com.cheeeese.global.security.jwt.JwtAuthenticationFilter;
+import com.cheeeese.oauth2.application.CustomOAuth2UserService;
+import com.cheeeese.oauth2.handler.OAuth2FailureHandler;
+import com.cheeeese.oauth2.handler.OAuth2SuccessHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestRedirectFilter;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final OAuth2SuccessHandler oAuth2SuccessHandler;
+    private final OAuth2FailureHandler oAuth2FailureHandler;
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .cors(Customizer.withDefaults())
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement((sessionManagement) -> sessionManagement
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests((requests) -> requests
+                        .requestMatchers(
+                                "/swagger-ui/**",
+                                "/v3/api-docs/**",
+                                "/v1/global/health-check",
+                                "/login/oauth2/**"
+                        ).permitAll()
+                        .anyRequest().authenticated())
+                .exceptionHandling(exceptions -> exceptions
+                        .authenticationEntryPoint(jwtAuthenticationEntryPoint)
+                        .accessDeniedHandler(jwtAccessDeniedHandler)
+                )
+                .oauth2Login(oauth2 -> oauth2
+                        .userInfoEndpoint(userInfo -> userInfo
+                                .userService(customOAuth2UserService))
+                        .successHandler(oAuth2SuccessHandler)
+                        .failureHandler(oAuth2FailureHandler)
+                )
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/cheeeese/global/config/SecurityConfig.java
+++ b/src/main/java/com/cheeeese/global/config/SecurityConfig.java
@@ -43,7 +43,8 @@ public class SecurityConfig {
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",
                                 "/v1/global/health-check",
-                                "/login/oauth2/**"
+                                "/login/oauth2/**",
+                                "/v1/auth/exchange"
                         ).permitAll()
                         .anyRequest().authenticated())
                 .exceptionHandling(exceptions -> exceptions

--- a/src/main/java/com/cheeeese/global/config/SwaggerConfig.java
+++ b/src/main/java/com/cheeeese/global/config/SwaggerConfig.java
@@ -3,7 +3,14 @@ package com.cheeeese.global.config;
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.servers.Server;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.Collections;
 
 @Configuration
 @OpenAPIDefinition(
@@ -18,4 +25,15 @@ import org.springframework.context.annotation.Configuration;
         )
 )
 public class SwaggerConfig {
+        @Bean
+        public OpenAPI openAPI() {
+                SecurityScheme securityScheme = new SecurityScheme()
+                        .type(SecurityScheme.Type.HTTP).scheme("Bearer").bearerFormat("JWT")
+                        .in(SecurityScheme.In.HEADER).name("Authorization");
+                SecurityRequirement securityRequirement = new SecurityRequirement().addList("BearerAuth");
+
+                return new OpenAPI()
+                        .components(new Components().addSecuritySchemes("BearerAuth", securityScheme))
+                        .security(Collections.singletonList(securityRequirement));
+        }
 }

--- a/src/main/java/com/cheeeese/global/config/WebConfig.java
+++ b/src/main/java/com/cheeeese/global/config/WebConfig.java
@@ -1,0 +1,21 @@
+package com.cheeeese.global.config;
+
+import com.cheeeese.global.util.resolver.CurrentUserResolver;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final CurrentUserResolver currentUserResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(currentUserResolver);
+    }
+}

--- a/src/main/java/com/cheeeese/global/security/CurrentUserProvider.java
+++ b/src/main/java/com/cheeeese/global/security/CurrentUserProvider.java
@@ -1,0 +1,21 @@
+package com.cheeeese.global.security;
+
+import com.cheeeese.user.domain.User;
+import com.cheeeese.user.exception.UserException;
+import com.cheeeese.user.exception.code.UserErrorCode;
+import com.cheeeese.user.infrastructure.persistence.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CurrentUserProvider {
+
+    private final UserRepository userRepository;
+
+    public User getCurrentUser() {
+        Long userId = SecurityUtils.getCurrentUserId();
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/cheeeese/global/security/CustomUserDetailService.java
+++ b/src/main/java/com/cheeeese/global/security/CustomUserDetailService.java
@@ -1,0 +1,26 @@
+package com.cheeeese.global.security;
+
+import com.cheeeese.global.common.code.ErrorCode;
+import com.cheeeese.global.exception.BusinessException;
+import com.cheeeese.user.domain.User;
+import com.cheeeese.user.infrastructure.persistence.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String userId) throws UsernameNotFoundException {
+        User user = userRepository.findById(Long.valueOf(userId))
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND)); // TODO: 에러 코드 수정
+
+        return new CustomUserDetails(user);
+    }
+}

--- a/src/main/java/com/cheeeese/global/security/CustomUserDetailService.java
+++ b/src/main/java/com/cheeeese/global/security/CustomUserDetailService.java
@@ -1,8 +1,8 @@
 package com.cheeeese.global.security;
 
-import com.cheeeese.global.common.code.ErrorCode;
-import com.cheeeese.global.exception.BusinessException;
 import com.cheeeese.user.domain.User;
+import com.cheeeese.user.exception.UserException;
+import com.cheeeese.user.exception.code.UserErrorCode;
 import com.cheeeese.user.infrastructure.persistence.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -19,7 +19,7 @@ public class CustomUserDetailService implements UserDetailsService {
     @Override
     public UserDetails loadUserByUsername(String userId) throws UsernameNotFoundException {
         User user = userRepository.findById(Long.valueOf(userId))
-                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND)); // TODO: 에러 코드 수정
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
 
         return new CustomUserDetails(user);
     }

--- a/src/main/java/com/cheeeese/global/security/CustomUserDetails.java
+++ b/src/main/java/com/cheeeese/global/security/CustomUserDetails.java
@@ -1,0 +1,81 @@
+package com.cheeeese.global.security;
+
+import com.cheeeese.user.domain.User;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+@Getter
+public class CustomUserDetails implements UserDetails, OAuth2User {
+
+    private final User user;
+    private final Map<String, Object> attributes;
+
+    public CustomUserDetails(User user) {
+        this.user = user;
+        this.attributes = Collections.emptyMap();
+    }
+
+    public CustomUserDetails(User user, Map<String, Object> attributes) {
+        this.user = user;
+        this.attributes = attributes;
+    }
+
+    public Long getId() {
+        return user.getId();
+    }
+
+    public String getEmail() {
+        return user.getEmail();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getEmail();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public String getName() {
+        return user.getName();
+    }
+}

--- a/src/main/java/com/cheeeese/global/security/SecurityUtils.java
+++ b/src/main/java/com/cheeeese/global/security/SecurityUtils.java
@@ -20,7 +20,12 @@ public class SecurityUtils {
         ) {
             throw new BusinessException(ErrorCode.UNAUTHORIZED);
         }
-        return ((CustomUserDetails) authentication.getPrincipal()).getUser();
+        Object principal = authentication.getPrincipal();
+
+        if (!(principal instanceof CustomUserDetails customUserDetails)) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED);
+        }
+        return customUserDetails.getUser();
     }
 
     public static Long getCurrentUserId() {

--- a/src/main/java/com/cheeeese/global/security/SecurityUtils.java
+++ b/src/main/java/com/cheeeese/global/security/SecurityUtils.java
@@ -1,0 +1,29 @@
+package com.cheeeese.global.security;
+
+import com.cheeeese.global.common.code.ErrorCode;
+import com.cheeeese.global.exception.BusinessException;
+import com.cheeeese.user.domain.User;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SecurityUtils {
+
+    public static User getCurrentUser() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null ||
+            !authentication.isAuthenticated() ||
+            authentication instanceof AnonymousAuthenticationToken
+        ) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED);
+        }
+        return ((CustomUserDetails) authentication.getPrincipal()).getUser();
+    }
+
+    public static Long getCurrentUserId() {
+        return getCurrentUser().getId();
+    }
+}

--- a/src/main/java/com/cheeeese/global/security/handler/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/cheeeese/global/security/handler/JwtAccessDeniedHandler.java
@@ -1,0 +1,33 @@
+package com.cheeeese.global.security.handler;
+
+import com.cheeeese.global.common.CommonResponse;
+import com.cheeeese.global.common.code.ErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void handle(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AccessDeniedException accessDeniedException
+    ) throws IOException {
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        objectMapper.writeValue(response.getWriter(), CommonResponse.failure(ErrorCode.FORBIDDEN));
+    }
+}

--- a/src/main/java/com/cheeeese/global/security/handler/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/cheeeese/global/security/handler/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,34 @@
+package com.cheeeese.global.security.handler;
+
+import com.cheeeese.global.common.CommonResponse;
+import com.cheeeese.global.common.code.ErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException authException
+    ) throws IOException {
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        objectMapper.writeValue(response.getWriter(), CommonResponse.failure(ErrorCode.UNAUTHORIZED));
+    }
+}

--- a/src/main/java/com/cheeeese/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/cheeeese/global/security/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,48 @@
+package com.cheeeese.global.security.jwt;
+
+import com.cheeeese.global.security.CustomUserDetailService;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtProvider jwtProvider;
+    private final CustomUserDetailService customUserDetailService;
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        String token = jwtProvider.resolveToken(request);
+
+        // TODO: 로그아웃 구현 후 관련 로직 추가
+
+        if (token != null && jwtProvider.validateToken(token)) {
+            Claims claims = jwtProvider.getClaims(token);
+            String userId = claims.getSubject();
+
+            UserDetails userDetails = customUserDetailService.loadUserByUsername(userId);
+
+            UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                    userDetails, null, userDetails.getAuthorities()
+            );
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/cheeeese/global/security/jwt/JwtProperties.java
+++ b/src/main/java/com/cheeeese/global/security/jwt/JwtProperties.java
@@ -5,7 +5,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "jwt")
 public record JwtProperties(
         String secret,
-        String accessExp,
-        String refreshExp
+        Long accessExp,
+        Long refreshExp
 ) {
 }

--- a/src/main/java/com/cheeeese/global/security/jwt/JwtProperties.java
+++ b/src/main/java/com/cheeeese/global/security/jwt/JwtProperties.java
@@ -1,0 +1,11 @@
+package com.cheeeese.global.security.jwt;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "jwt")
+public record JwtProperties(
+        String secret,
+        String accessExp,
+        String refreshExp
+) {
+}

--- a/src/main/java/com/cheeeese/global/security/jwt/JwtProvider.java
+++ b/src/main/java/com/cheeeese/global/security/jwt/JwtProvider.java
@@ -2,15 +2,13 @@ package com.cheeeese.global.security.jwt;
 
 import com.cheeeese.auth.exception.AuthException;
 import com.cheeeese.auth.exception.code.AuthErrorCode;
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import javax.crypto.SecretKey;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
 
@@ -28,7 +26,7 @@ public class JwtProvider {
                 .setSubject(userId.toString())
                 .setIssuedAt(now)
                 .setExpiration(expiration)
-                .signWith(Keys.hmacShaKeyFor(jwtProperties.secret().getBytes(StandardCharsets.UTF_8)),  SignatureAlgorithm.HS256)
+                .signWith(getSigningKey(), SignatureAlgorithm.HS256)
                 .compact();
     }
 
@@ -40,14 +38,14 @@ public class JwtProvider {
                 .setSubject(userId.toString())
                 .setIssuedAt(now)
                 .setExpiration(expiration)
-                .signWith(Keys.hmacShaKeyFor(jwtProperties.secret().getBytes(StandardCharsets.UTF_8)),  SignatureAlgorithm.HS256)
+                .signWith(getSigningKey(), SignatureAlgorithm.HS256)
                 .compact();
     }
 
     public Claims getClaims(String token) {
         try {
             return Jwts.parserBuilder()
-                    .setSigningKey(Keys.hmacShaKeyFor(jwtProperties.secret().getBytes()))
+                    .setSigningKey(getSigningKey())
                     .build()
                     .parseClaimsJws(token)
                     .getBody();
@@ -59,12 +57,14 @@ public class JwtProvider {
     public boolean validateToken(String token) {
         try {
             Jwts.parserBuilder()
-                    .setSigningKey(Keys.hmacShaKeyFor(jwtProperties.secret().getBytes(StandardCharsets.UTF_8)))
+                    .setSigningKey(getSigningKey())
                     .build()
                     .parseClaimsJws(token);
 
             return true;
         } catch (ExpiredJwtException e) {
+            throw new AuthException(AuthErrorCode.EXPIRED_TOKEN);
+        } catch (MalformedJwtException | UnsupportedJwtException e) {
             throw new AuthException(AuthErrorCode.INVALID_TOKEN);
         }
     }
@@ -76,5 +76,9 @@ public class JwtProvider {
             return bearerToken.substring(7);
         }
         return null;
+    }
+
+    private SecretKey getSigningKey() {
+        return Keys.hmacShaKeyFor(jwtProperties.secret().getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/src/main/java/com/cheeeese/global/security/jwt/JwtProvider.java
+++ b/src/main/java/com/cheeeese/global/security/jwt/JwtProvider.java
@@ -7,6 +7,7 @@ import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -68,5 +69,14 @@ public class JwtProvider {
         } catch (ExpiredJwtException e) {
             throw new BusinessException(ErrorCode.INVALID_TOKEN);
         }
+    }
+
+    public String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
     }
 }

--- a/src/main/java/com/cheeeese/global/security/jwt/JwtProvider.java
+++ b/src/main/java/com/cheeeese/global/security/jwt/JwtProvider.java
@@ -1,0 +1,72 @@
+package com.cheeeese.global.security.jwt;
+
+import com.cheeeese.global.common.code.ErrorCode;
+import com.cheeeese.global.exception.BusinessException;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Component
+@RequiredArgsConstructor
+public class JwtProvider {
+
+    private final JwtProperties jwtProperties;
+
+    public String createAccessToken(Long userId) {
+        Date now = new Date();
+        Date expiration = new Date(now.getTime() + jwtProperties.accessExp());
+
+        return Jwts.builder()
+                .setSubject(userId.toString())
+                .setIssuedAt(now)
+                .setExpiration(expiration)
+                .signWith(Keys.hmacShaKeyFor(jwtProperties.secret().getBytes(StandardCharsets.UTF_8)),  SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public String createRefreshToken(Long userId) {
+        Date now = new Date();
+        Date expiration = new Date(now.getTime() + jwtProperties.refreshExp());
+
+        return Jwts.builder()
+                .setSubject(userId.toString())
+                .setIssuedAt(now)
+                .setExpiration(expiration)
+                .signWith(Keys.hmacShaKeyFor(jwtProperties.secret().getBytes(StandardCharsets.UTF_8)),  SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public Claims getClaims(String token) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(Keys.hmacShaKeyFor(jwtProperties.secret().getBytes()))
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Claims claims = getClaims(token);
+
+            Jwts.parserBuilder()
+                    .setSigningKey(Keys.hmacShaKeyFor(jwtProperties.secret().getBytes(StandardCharsets.UTF_8)))
+                    .build()
+                    .parseClaimsJws(token);
+
+            return true;
+        } catch (ExpiredJwtException e) {
+            throw new BusinessException(ErrorCode.INVALID_TOKEN);
+        }
+    }
+}

--- a/src/main/java/com/cheeeese/global/security/jwt/JwtProvider.java
+++ b/src/main/java/com/cheeeese/global/security/jwt/JwtProvider.java
@@ -69,7 +69,7 @@ public class JwtProvider {
 
             return true;
         } catch (ExpiredJwtException e) {
-            throw new BusinessException(ErrorCode.INVALID_TOKEN);
+            throw new AuthException(AuthErrorCode.INVALID_TOKEN);
         }
     }
 

--- a/src/main/java/com/cheeeese/global/security/jwt/JwtProvider.java
+++ b/src/main/java/com/cheeeese/global/security/jwt/JwtProvider.java
@@ -1,5 +1,7 @@
 package com.cheeeese.global.security.jwt;
 
+import com.cheeeese.auth.exception.AuthException;
+import com.cheeeese.auth.exception.code.AuthErrorCode;
 import com.cheeeese.global.common.code.ErrorCode;
 import com.cheeeese.global.exception.BusinessException;
 import io.jsonwebtoken.Claims;

--- a/src/main/java/com/cheeeese/global/security/jwt/JwtProvider.java
+++ b/src/main/java/com/cheeeese/global/security/jwt/JwtProvider.java
@@ -2,8 +2,6 @@ package com.cheeeese.global.security.jwt;
 
 import com.cheeeese.auth.exception.AuthException;
 import com.cheeeese.auth.exception.code.AuthErrorCode;
-import com.cheeeese.global.common.code.ErrorCode;
-import com.cheeeese.global.exception.BusinessException;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
@@ -60,8 +58,6 @@ public class JwtProvider {
 
     public boolean validateToken(String token) {
         try {
-            Claims claims = getClaims(token);
-
             Jwts.parserBuilder()
                     .setSigningKey(Keys.hmacShaKeyFor(jwtProperties.secret().getBytes(StandardCharsets.UTF_8)))
                     .build()

--- a/src/main/java/com/cheeeese/global/util/CurrentUser.java
+++ b/src/main/java/com/cheeeese/global/util/CurrentUser.java
@@ -1,0 +1,14 @@
+package com.cheeeese.global.util;
+
+import io.swagger.v3.oas.annotations.Parameter;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+@Parameter(hidden = true)
+public @interface CurrentUser {
+}

--- a/src/main/java/com/cheeeese/global/util/RedisUtil.java
+++ b/src/main/java/com/cheeeese/global/util/RedisUtil.java
@@ -1,0 +1,26 @@
+package com.cheeeese.global.util;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+@Component
+@RequiredArgsConstructor
+public class RedisUtil {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public void setValue(String key, Object value, Long expiredTime) {
+        redisTemplate.opsForValue().set(key, value, expiredTime, TimeUnit.MILLISECONDS);
+    }
+
+    public String getValue(String key) {
+        return (String) redisTemplate.opsForValue().get(key);
+    }
+
+    public void deleteValue(String key) {
+        redisTemplate.delete(key);
+    }
+}

--- a/src/main/java/com/cheeeese/global/util/resolver/CurrentUserResolver.java
+++ b/src/main/java/com/cheeeese/global/util/resolver/CurrentUserResolver.java
@@ -1,0 +1,39 @@
+package com.cheeeese.global.util.resolver;
+
+import com.cheeeese.global.security.SecurityUtils;
+import com.cheeeese.global.util.CurrentUser;
+import com.cheeeese.user.domain.User;
+import com.cheeeese.user.exception.UserException;
+import com.cheeeese.user.exception.code.UserErrorCode;
+import com.cheeeese.user.infrastructure.persistence.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+@RequiredArgsConstructor
+public class CurrentUserResolver implements HandlerMethodArgumentResolver {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(CurrentUser.class) && parameter.getParameterType().equals(User.class);
+    }
+
+    @Override
+    public Object resolveArgument(
+            MethodParameter parameter,
+            ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest,
+            WebDataBinderFactory binderFactory
+    ) {
+        Long userId = SecurityUtils.getCurrentUserId();
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/cheeeese/oauth2/application/CustomOAuth2UserService.java
+++ b/src/main/java/com/cheeeese/oauth2/application/CustomOAuth2UserService.java
@@ -29,7 +29,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
         KakaoUserInfo userInfo = extractKakaoUserInfo(attributes);
 
-        User user = userRepository.findByEmail(userInfo.getEmail())
+        User user = userRepository.findByProviderId(userInfo.getProviderId())
                 .orElseGet(() -> {
                     User newUser = UserMapper.toEntity(userInfo);
                     return userRepository.save(newUser);

--- a/src/main/java/com/cheeeese/oauth2/application/CustomOAuth2UserService.java
+++ b/src/main/java/com/cheeeese/oauth2/application/CustomOAuth2UserService.java
@@ -1,0 +1,44 @@
+package com.cheeeese.oauth2.application;
+
+import com.cheeeese.global.security.CustomUserDetails;
+import com.cheeeese.oauth2.infrastructure.userinfo.KakaoUserInfo;
+import com.cheeeese.user.domain.User;
+import com.cheeeese.user.infrastructure.mapper.UserMapper;
+import com.cheeeese.user.infrastructure.persistence.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+        Map<String, Object> attributes = oAuth2User.getAttributes();
+
+        KakaoUserInfo userInfo = extractKakaoUserInfo(attributes);
+
+        User user = userRepository.findByEmail(userInfo.getEmail())
+                .orElseGet(() -> {
+                    User newUser = UserMapper.toEntity(userInfo);
+                    return userRepository.save(newUser);
+                });
+
+        return new CustomUserDetails(user, attributes);
+    }
+
+    private KakaoUserInfo extractKakaoUserInfo(Map<String, Object> attributes) {
+        return new KakaoUserInfo(attributes);
+    }
+}

--- a/src/main/java/com/cheeeese/oauth2/domain/OAuth2UserInfo.java
+++ b/src/main/java/com/cheeeese/oauth2/domain/OAuth2UserInfo.java
@@ -3,6 +3,6 @@ package com.cheeeese.oauth2.domain;
 public interface OAuth2UserInfo {
     String getProviderId();
     String getEmail();
-    String getName ();
+    String getName();
     String getProfileImage();
 }

--- a/src/main/java/com/cheeeese/oauth2/domain/OAuth2UserInfo.java
+++ b/src/main/java/com/cheeeese/oauth2/domain/OAuth2UserInfo.java
@@ -1,0 +1,8 @@
+package com.cheeeese.oauth2.domain;
+
+public interface OAuth2UserInfo {
+    String getProviderId();
+    String getEmail();
+    String getName ();
+    String getProfileImage();
+}

--- a/src/main/java/com/cheeeese/oauth2/domain/RefreshToken.java
+++ b/src/main/java/com/cheeeese/oauth2/domain/RefreshToken.java
@@ -1,0 +1,30 @@
+package com.cheeeese.oauth2.domain;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+
+@Getter
+@NoArgsConstructor
+@RedisHash(value = "refreshToken")
+public class RefreshToken {
+
+    @Id
+    private Long userId;
+
+    private String refreshToken;
+
+    @TimeToLive
+    private Long expiration = 604800L;
+
+    public RefreshToken(Long userId, String refreshToken) {
+        this.userId = userId;
+        this.refreshToken = refreshToken;
+    }
+
+    public void updateRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+}

--- a/src/main/java/com/cheeeese/oauth2/domain/RefreshToken.java
+++ b/src/main/java/com/cheeeese/oauth2/domain/RefreshToken.java
@@ -1,5 +1,6 @@
 package com.cheeeese.oauth2.domain;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Id;
@@ -19,7 +20,8 @@ public class RefreshToken {
     @TimeToLive
     private Long expiration = 604800L;
 
-    public RefreshToken(Long userId, String refreshToken) {
+    @Builder
+    private RefreshToken(Long userId, String refreshToken) {
         this.userId = userId;
         this.refreshToken = refreshToken;
     }

--- a/src/main/java/com/cheeeese/oauth2/handler/OAuth2FailureHandler.java
+++ b/src/main/java/com/cheeeese/oauth2/handler/OAuth2FailureHandler.java
@@ -1,0 +1,37 @@
+package com.cheeeese.oauth2.handler;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuth2FailureHandler extends SimpleUrlAuthenticationFailureHandler {
+
+    @Value("${frontend.oauth2.failure-redirect-uri}")
+    private String failureRedirectUri;
+
+    @Override
+    public void onAuthenticationFailure(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException exception
+    ) throws IOException {
+        log.warn("⚠️ 로그인 실패: {}", exception.getMessage());
+
+        String redirectUri = UriComponentsBuilder.fromUriString(failureRedirectUri)
+                .queryParam("error",exception.getLocalizedMessage())
+                .build().toUriString();
+
+        getRedirectStrategy().sendRedirect(request, response, redirectUri);
+    }
+}

--- a/src/main/java/com/cheeeese/oauth2/handler/OAuth2FailureHandler.java
+++ b/src/main/java/com/cheeeese/oauth2/handler/OAuth2FailureHandler.java
@@ -17,8 +17,8 @@ import java.io.IOException;
 @RequiredArgsConstructor
 public class OAuth2FailureHandler extends SimpleUrlAuthenticationFailureHandler {
 
-    @Value("${frontend.oauth2.failure-redirect-uri}")
-    private String failureRedirectUri;
+    @Value("${frontend.oauth2.redirect-uri}")
+    private String redirectUri;
 
     @Override
     public void onAuthenticationFailure(
@@ -28,10 +28,10 @@ public class OAuth2FailureHandler extends SimpleUrlAuthenticationFailureHandler 
     ) throws IOException {
         log.warn("⚠️ 로그인 실패: {}", exception.getMessage());
 
-        String redirectUri = UriComponentsBuilder.fromUriString(failureRedirectUri)
+        String targetUri = UriComponentsBuilder.fromUriString(redirectUri)
                 .queryParam("error",exception.getLocalizedMessage())
                 .build().toUriString();
 
-        getRedirectStrategy().sendRedirect(request, response, redirectUri);
+        getRedirectStrategy().sendRedirect(request, response, targetUri);
     }
 }

--- a/src/main/java/com/cheeeese/oauth2/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/cheeeese/oauth2/handler/OAuth2SuccessHandler.java
@@ -1,0 +1,61 @@
+package com.cheeeese.oauth2.handler;
+
+import com.cheeeese.global.security.CustomUserDetails;
+import com.cheeeese.global.security.jwt.JwtProvider;
+import com.cheeeese.global.util.RedisUtil;
+import com.cheeeese.oauth2.infrastructure.RefreshTokenMapper;
+import com.cheeeese.oauth2.infrastructure.persistence.RefreshTokenRepository;
+import com.cheeeese.user.domain.User;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
+
+    private final JwtProvider jwtProvider;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final ObjectMapper objectMapper;
+    private final RedisUtil redisUtil;
+
+    @Value("${frontend.oauth2.redirect-uri}")
+    private String redirectUri;
+
+    @Override
+    public void onAuthenticationSuccess(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            Authentication authentication
+    ) throws IOException {
+        CustomUserDetails customUserDetails = (CustomUserDetails) authentication.getPrincipal();
+        User user = customUserDetails.getUser();
+
+        String accessToken = jwtProvider.createAccessToken(user.getId());
+        String refreshToken = jwtProvider.createRefreshToken(user.getId());
+
+        refreshTokenRepository.save(RefreshTokenMapper.toRefreshToken(user, refreshToken));
+
+        String tempCode = UUID.randomUUID().toString();
+
+        redisUtil.setValue("auth:" + tempCode,
+                objectMapper.writeValueAsString(Map.of(
+                        "accessToken", accessToken,
+                        "refreshToken", refreshToken
+                )),
+                1000 * 60L
+        );
+
+        String callbackUri = redirectUri + tempCode;
+        response.sendRedirect(callbackUri);
+    }
+}

--- a/src/main/java/com/cheeeese/oauth2/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/cheeeese/oauth2/handler/OAuth2SuccessHandler.java
@@ -3,7 +3,7 @@ package com.cheeeese.oauth2.handler;
 import com.cheeeese.global.security.CustomUserDetails;
 import com.cheeeese.global.security.jwt.JwtProvider;
 import com.cheeeese.global.util.RedisUtil;
-import com.cheeeese.oauth2.infrastructure.RefreshTokenMapper;
+import com.cheeeese.oauth2.infrastructure.mapper.RefreshTokenMapper;
 import com.cheeeese.oauth2.infrastructure.persistence.RefreshTokenRepository;
 import com.cheeeese.user.domain.User;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/main/java/com/cheeeese/oauth2/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/cheeeese/oauth2/handler/OAuth2SuccessHandler.java
@@ -14,6 +14,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
 import java.util.Map;
@@ -55,7 +56,12 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
                 1000 * 60L
         );
 
-        String callbackUri = redirectUri + tempCode;
+        String callbackUri = UriComponentsBuilder
+                .fromUriString(redirectUri)
+                .queryParam("code", tempCode)
+                .build()
+                .toUriString();
+
         response.sendRedirect(callbackUri);
     }
 }

--- a/src/main/java/com/cheeeese/oauth2/infrastructure/RefreshTokenMapper.java
+++ b/src/main/java/com/cheeeese/oauth2/infrastructure/RefreshTokenMapper.java
@@ -1,0 +1,14 @@
+package com.cheeeese.oauth2.infrastructure;
+
+import com.cheeeese.oauth2.domain.RefreshToken;
+import com.cheeeese.user.domain.User;
+
+public class RefreshTokenMapper {
+
+    public static RefreshToken toRefreshToken(User user, String refreshToken) {
+        return RefreshToken.builder()
+                .userId(user.getId())
+                .refreshToken(refreshToken)
+                .build();
+    }
+}

--- a/src/main/java/com/cheeeese/oauth2/infrastructure/mapper/RefreshTokenMapper.java
+++ b/src/main/java/com/cheeeese/oauth2/infrastructure/mapper/RefreshTokenMapper.java
@@ -1,4 +1,4 @@
-package com.cheeeese.oauth2.infrastructure;
+package com.cheeeese.oauth2.infrastructure.mapper;
 
 import com.cheeeese.oauth2.domain.RefreshToken;
 import com.cheeeese.user.domain.User;

--- a/src/main/java/com/cheeeese/oauth2/infrastructure/persistence/RefreshTokenRepository.java
+++ b/src/main/java/com/cheeeese/oauth2/infrastructure/persistence/RefreshTokenRepository.java
@@ -1,0 +1,7 @@
+package com.cheeeese.oauth2.infrastructure.persistence;
+
+import com.cheeeese.oauth2.domain.RefreshToken;
+import org.springframework.data.repository.CrudRepository;
+
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, Long> {
+}

--- a/src/main/java/com/cheeeese/oauth2/infrastructure/userinfo/KakaoUserInfo.java
+++ b/src/main/java/com/cheeeese/oauth2/infrastructure/userinfo/KakaoUserInfo.java
@@ -3,6 +3,7 @@ package com.cheeeese.oauth2.infrastructure.userinfo;
 import com.cheeeese.oauth2.domain.OAuth2UserInfo;
 import lombok.RequiredArgsConstructor;
 
+import java.util.Collections;
 import java.util.Map;
 
 @RequiredArgsConstructor
@@ -17,36 +18,34 @@ public class KakaoUserInfo implements OAuth2UserInfo {
 
     @Override
     public String getEmail() {
-        Map<String, Object> accountMap = (Map<String, Object>) attributes.get("kakao_account");
-        if (accountMap == null) {
-            return null;
-        }
-        return (String) accountMap.get("email");
+        return (String) getKakaoAccount().get("email");
     }
 
     @Override
     public String getName() {
-        Map<String, Object> accountMap = (Map<String, Object>) attributes.get("kakao_account");
-        if (accountMap == null) {
-            return null;
-        }
-        Map<String, Object> profileMap = (Map<String, Object>) accountMap.get("profile");
-        if (profileMap == null) {
-            return null;
-        }
-        return (String) profileMap.get("nickname");
+        return (String) getKakaoProfile().get("nickname");
     }
 
     @Override
     public String getProfileImage() {
-        Map<String, Object> accountMap = (Map<String, Object>) attributes.get("kakao_account");
-        if (accountMap == null) {
-            return null;
+        return (String) getKakaoProfile().get("profile_image_url");
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> getKakaoAccount() {
+        Object account = attributes.get("kakao_account");
+        if (account instanceof Map) {
+            return (Map<String, Object>) account;
         }
-        Map<String, Object> profileMap = (Map<String, Object>) accountMap.get("profile");
-        if (profileMap == null) {
-            return null;
+        return Collections.emptyMap();
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> getKakaoProfile() {
+        Object profile = attributes.get("profile");
+        if (profile instanceof Map) {
+            return (Map<String, Object>) profile;
         }
-        return (String) profileMap.get("profile_image_url");
+        return Collections.emptyMap();
     }
 }

--- a/src/main/java/com/cheeeese/oauth2/infrastructure/userinfo/KakaoUserInfo.java
+++ b/src/main/java/com/cheeeese/oauth2/infrastructure/userinfo/KakaoUserInfo.java
@@ -1,0 +1,52 @@
+package com.cheeeese.oauth2.infrastructure.userinfo;
+
+import com.cheeeese.oauth2.domain.OAuth2UserInfo;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Map;
+
+@RequiredArgsConstructor
+public class KakaoUserInfo implements OAuth2UserInfo {
+
+    private final Map<String, Object> attributes;
+
+    @Override
+    public String getProviderId() {
+        return String.valueOf(attributes.get("id"));
+    }
+
+    @Override
+    public String getEmail() {
+        Map<String, Object> accountMap = (Map<String, Object>) attributes.get("kakao_account");
+        if (accountMap == null) {
+            return null;
+        }
+        return (String) accountMap.get("email");
+    }
+
+    @Override
+    public String getName() {
+        Map<String, Object> accountMap = (Map<String, Object>) attributes.get("kakao_account");
+        if (accountMap == null) {
+            return null;
+        }
+        Map<String, Object> profileMap = (Map<String, Object>) accountMap.get("profile");
+        if (profileMap == null) {
+            return null;
+        }
+        return (String) profileMap.get("nickname");
+    }
+
+    @Override
+    public String getProfileImage() {
+        Map<String, Object> accountMap = (Map<String, Object>) attributes.get("kakao_account");
+        if (accountMap == null) {
+            return null;
+        }
+        Map<String, Object> profileMap = (Map<String, Object>) accountMap.get("profile");
+        if (profileMap == null) {
+            return null;
+        }
+        return (String) profileMap.get("profile_image_url");
+    }
+}

--- a/src/main/java/com/cheeeese/user/domain/User.java
+++ b/src/main/java/com/cheeeese/user/domain/User.java
@@ -20,7 +20,7 @@ public class User extends BaseEntity {
     @Column(name = "name", nullable = false)
     private String name;
 
-    @Column(name = "email", nullable = false)
+    @Column(name = "email", nullable = false, unique = true)
     private String email;
 
     @Column(name = "profile_image")

--- a/src/main/java/com/cheeeese/user/domain/User.java
+++ b/src/main/java/com/cheeeese/user/domain/User.java
@@ -1,0 +1,44 @@
+package com.cheeeese.user.domain;
+
+import com.cheeeese.global.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User extends BaseEntity {
+
+    @Id
+    @Column(name = "user_id", nullable = false)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "email", nullable = false)
+    private String email;
+
+    @Column(name = "profile_image")
+    private String profileImage;
+
+    @Column(name = "provider_id", nullable = false)
+    private String providerId;
+
+    @Builder
+    private User(
+            String name,
+            String email,
+            String profileImage,
+            String providerId
+    ) {
+        this.name = name;
+        this.email = email;
+        this.profileImage = profileImage;
+        this.providerId = providerId;
+    }
+}

--- a/src/main/java/com/cheeeese/user/domain/User.java
+++ b/src/main/java/com/cheeeese/user/domain/User.java
@@ -29,16 +29,51 @@ public class User extends BaseEntity {
     @Column(name = "provider_id", nullable = false)
     private String providerId;
 
+    @Column(name = "is_service_agreement")
+    private Boolean isServiceAgreement;
+
+    @Column(name = "is_user_info_agreement")
+    private Boolean isUserInfoAgreement;
+
+    @Column(name = "is_marketing_agreement")
+    private Boolean isMarketingAgreement;
+
+    @Column(name = "is_third_party_agreement")
+    private Boolean isThirdPartyAgreement;
+
+    @Column(name = "album_cnt")
+    private int albumCnt;
+
+    @Column(name = "photo_cnt")
+    private int photoCnt;
+
+    @Column(name = "likes_cnt")
+    private int likesCnt;
+
     @Builder
     private User(
             String name,
             String email,
             String profileImage,
-            String providerId
+            String providerId,
+            Boolean isServiceAgreement,
+            Boolean isUserInfoAgreement,
+            Boolean isMarketingAgreement,
+            Boolean isThirdPartyAgreement,
+            int albumCnt,
+            int photoCnt,
+            int likesCnt
     ) {
         this.name = name;
         this.email = email;
         this.profileImage = profileImage;
         this.providerId = providerId;
+        this.isServiceAgreement = isServiceAgreement;
+        this.isUserInfoAgreement = isUserInfoAgreement;
+        this.isMarketingAgreement = isMarketingAgreement;
+        this.isThirdPartyAgreement = isThirdPartyAgreement;
+        this.albumCnt = albumCnt;
+        this.photoCnt = photoCnt;
+        this.likesCnt = likesCnt;
     }
 }

--- a/src/main/java/com/cheeeese/user/exception/UserException.java
+++ b/src/main/java/com/cheeeese/user/exception/UserException.java
@@ -1,0 +1,12 @@
+package com.cheeeese.user.exception;
+
+import com.cheeeese.global.exception.BusinessException;
+import com.cheeeese.user.exception.code.UserErrorCode;
+import lombok.Getter;
+
+@Getter
+public class UserException extends BusinessException {
+    public UserException(UserErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/cheeeese/user/exception/code/UserErrorCode.java
+++ b/src/main/java/com/cheeeese/user/exception/code/UserErrorCode.java
@@ -1,0 +1,17 @@
+package com.cheeeese.user.exception.code;
+
+import com.cheeeese.global.common.code.BaseCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserErrorCode implements BaseCode {
+
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/cheeeese/user/infrastructure/mapper/UserMapper.java
+++ b/src/main/java/com/cheeeese/user/infrastructure/mapper/UserMapper.java
@@ -1,0 +1,16 @@
+package com.cheeeese.user.infrastructure.mapper;
+
+import com.cheeeese.oauth2.domain.OAuth2UserInfo;
+import com.cheeeese.user.domain.User;
+
+public class UserMapper {
+
+    public static User toEntity(OAuth2UserInfo oAuth2UserInfo) {
+        return User.builder()
+                .email(oAuth2UserInfo.getEmail())
+                .name(oAuth2UserInfo.getName())
+                .profileImage(oAuth2UserInfo.getProfileImage())
+                .providerId(oAuth2UserInfo.getProviderId())
+                .build();
+    }
+}

--- a/src/main/java/com/cheeeese/user/infrastructure/persistence/UserRepository.java
+++ b/src/main/java/com/cheeeese/user/infrastructure/persistence/UserRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
-    Optional<User> findByEmail(String email);
+    Optional<User> findByProviderId(String providerId);
 }

--- a/src/main/java/com/cheeeese/user/infrastructure/persistence/UserRepository.java
+++ b/src/main/java/com/cheeeese/user/infrastructure/persistence/UserRepository.java
@@ -1,0 +1,7 @@
+package com.cheeeese.user.infrastructure.persistence;
+
+import com.cheeeese.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/com/cheeeese/user/infrastructure/persistence/UserRepository.java
+++ b/src/main/java/com/cheeeese/user/infrastructure/persistence/UserRepository.java
@@ -3,5 +3,8 @@ package com.cheeeese.user.infrastructure.persistence;
 import com.cheeeese.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
 }


### PR DESCRIPTION
## 🔗 연관된 이슈
- #3

## 🚀 변경 유형
- [x] ✨ 기능 추가 (feature)
- [ ] 🐛 버그 수정 (fix)
- [ ] 📝 문서 변경 (docs)
- [ ] ♻️ 리팩토링 (refactor)
- [ ] 🧪 테스트 추가 / 수정 (test)
- [ ] ⚙️ 설정 변경 (chore)

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 사용자 엔티티 구현
- 카카오 소셜 로그인 구현

## 📸 스크린샷
> 임시 코드 발급
<img width="946" height="262" alt="image" src="https://github.com/user-attachments/assets/9fad11f7-54b8-4e06-8e8a-72fb87e8f07f" />

> 코드 -> 토큰 교환
<img width="505" height="460" alt="image" src="https://github.com/user-attachments/assets/cf45a7d7-daea-4b44-bf61-739b0bd04cfe" />

## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
- yml이 많이 바뀌엇습니다... 노션에 업데이트 해놓을게요
- `name` = 카카오 사용자 이름이랑 치이이즈에서 사용할 닉네임을 별도의 컬럼으로 둘 지 카카오 사용자 이름을 계속 수정하는 방식으로 갈 지 고민됩니당. 머가 좋을지 추천해주세요..
- `controller`에서 현재 로그인 사용자를 바로 주입 받을 수 있도록 `CurrentUser` 어노테이션을 만들엇습니다. `CurrentUserProvider`는 컨트롤러에서 주입 받지 않는 로직에서 사용할 수도 있을 것 같아 일단 남겨 놓았는데 필요 없을 것 같으면 말해주세야

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - OAuth2 로그인 도입 및 JWT 기반 인증/인가 적용
  - 임시 코드로 액세스·리프레시 토큰과 사용자 정보를 반환하는 토큰 교환 API 추가
  - 리프레시 토큰 및 임시 코드 저장을 위한 Redis 연동
  - 보안 예외 처리(401/403) 응답 표준화
  - Swagger/OpenAPI에 Bearer JWT 보안 스키마 및 인증 문서화 추가
  - 컨트롤러에서 현재 사용자 주입을 위한 편의 어노테이션/리졸버 제공

- Chores
  - OAuth2, JWT, Redis, 보안 테스트 등 관련 빌드 의존성 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->