### PR TITLE
feat: 사용자 로그아웃 구현

### DIFF
--- a/src/main/java/com/cheeeese/auth/application/AuthService.java
+++ b/src/main/java/com/cheeeese/auth/application/AuthService.java
@@ -37,7 +37,7 @@ public class AuthService {
     private final ObjectMapper objectMapper;
     private final RedisUtil redisUtil;
     private final AuthValidator authValidator;
-    private final TokenBlackListService tokenBlackListService;
+    private final TokenBlacklistService tokenBlacklistService;
 
     public AuthExchangeResponse exchangeTempCode(String code) {
         Map<String, String> tokens = getTokenFromTempCode(code);
@@ -80,7 +80,7 @@ public class AuthService {
         if (expiration <= 0) {
             expiration = 1000;
         }
-        tokenBlackListService.addBlackList(accessToken, "logout", Duration.ofMillis(expiration));
+        tokenBlacklistService.addBlackList(accessToken, "logout", Duration.ofMillis(expiration));
     }
 
     private Map<String, String> getTokenFromTempCode(String code) {

--- a/src/main/java/com/cheeeese/auth/application/AuthService.java
+++ b/src/main/java/com/cheeeese/auth/application/AuthService.java
@@ -70,9 +70,7 @@ public class AuthService {
         User user = getUserFromToken(accessToken);
         Claims claims = jwtProvider.getClaims(accessToken);
 
-        RefreshToken refreshToken = refreshTokenRepository.findByUserId(user.getId())
-                .orElseThrow(() -> new AuthException(AuthErrorCode.REFRESH_TOKEN_NOT_FOUND));
-
+        RefreshToken refreshToken = authValidator.getRefreshTokenByUserId(user.getId());
         refreshTokenRepository.delete(refreshToken);
 
         long expiration = claims.getExpiration().getTime() - System.currentTimeMillis();

--- a/src/main/java/com/cheeeese/auth/application/AuthService.java
+++ b/src/main/java/com/cheeeese/auth/application/AuthService.java
@@ -23,6 +23,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
 import java.util.Map;
 
 @Service
@@ -36,6 +37,7 @@ public class AuthService {
     private final ObjectMapper objectMapper;
     private final RedisUtil redisUtil;
     private final AuthValidator authValidator;
+    private final TokenBlackListService tokenBlackListService;
 
     public AuthExchangeResponse exchangeTempCode(String code) {
         Map<String, String> tokens = getTokenFromTempCode(code);
@@ -61,6 +63,24 @@ public class AuthService {
         refreshTokenRepository.save(savedToken);
 
         return AuthMapper.toReissueResponse(newAccessToken, newRefreshToken);
+    }
+
+    @Transactional
+    public void logout(String accessToken) {
+        User user = getUserFromToken(accessToken);
+        Claims claims = jwtProvider.getClaims(accessToken);
+
+        RefreshToken refreshToken = refreshTokenRepository.findByUserId(user.getId())
+                .orElseThrow(() -> new AuthException(AuthErrorCode.REFRESH_TOKEN_NOT_FOUND));
+
+        refreshTokenRepository.delete(refreshToken);
+
+        long expiration = claims.getExpiration().getTime() - System.currentTimeMillis();
+
+        if (expiration <= 0) {
+            expiration = 1000;
+        }
+        tokenBlackListService.addBlackList(accessToken, "logout", Duration.ofMillis(expiration));
     }
 
     private Map<String, String> getTokenFromTempCode(String code) {

--- a/src/main/java/com/cheeeese/auth/application/TokenBlackListService.java
+++ b/src/main/java/com/cheeeese/auth/application/TokenBlackListService.java
@@ -1,0 +1,25 @@
+package com.cheeeese.auth.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@Service
+@RequiredArgsConstructor
+public class TokenBlackListService {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private static final String BLACKLIST_PREFIX = "accessTokenBlackList:";
+
+    public void addBlackList(String token, Object o, Duration expiration) {
+        String key = BLACKLIST_PREFIX + token;
+        redisTemplate.opsForValue().set(key, o, expiration);
+    }
+
+    public boolean isBlackListed(String token) {
+        String key = BLACKLIST_PREFIX + token;
+        return redisTemplate.hasKey(key);
+    }
+}

--- a/src/main/java/com/cheeeese/auth/application/TokenBlacklistService.java
+++ b/src/main/java/com/cheeeese/auth/application/TokenBlacklistService.java
@@ -8,7 +8,7 @@ import java.time.Duration;
 
 @Service
 @RequiredArgsConstructor
-public class TokenBlackListService {
+public class TokenBlacklistService {
 
     private final RedisTemplate<String, Object> redisTemplate;
     private static final String BLACKLIST_PREFIX = "accessTokenBlackList:";

--- a/src/main/java/com/cheeeese/auth/application/validator/AuthValidator.java
+++ b/src/main/java/com/cheeeese/auth/application/validator/AuthValidator.java
@@ -13,9 +13,13 @@ public class AuthValidator {
 
     private final RefreshTokenRepository refreshTokenRepository;
 
-    public RefreshToken validateRefreshToken(Long userId, String refreshToken) {
-        RefreshToken savedToken = refreshTokenRepository.findByUserId(userId)
+    public RefreshToken getRefreshTokenByUserId(Long userId) {
+        return refreshTokenRepository.findByUserId(userId)
                 .orElseThrow(() -> new AuthException(AuthErrorCode.REFRESH_TOKEN_NOT_FOUND));
+    }
+
+    public RefreshToken validateRefreshToken(Long userId, String refreshToken) {
+        RefreshToken savedToken = getRefreshTokenByUserId(userId);
 
         if (!savedToken.getRefreshToken().equals(refreshToken)) {
             throw new AuthException(AuthErrorCode.INVALID_TOKEN);

--- a/src/main/java/com/cheeeese/auth/exception/code/AuthErrorCode.java
+++ b/src/main/java/com/cheeeese/auth/exception/code/AuthErrorCode.java
@@ -14,6 +14,7 @@ public enum AuthErrorCode implements BaseCode {
     INVALID_AUTH_CODE(HttpStatus.BAD_REQUEST, "유효하지 않은 인증 코드 입니다."),
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
     REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "리프레시 토큰을 찾을 수 없습니다."),
+    LOGGED_OUT_TOKEN(HttpStatus.UNAUTHORIZED, "이미 로그아웃된 토큰입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/cheeeese/auth/presentation/AuthController.java
+++ b/src/main/java/com/cheeeese/auth/presentation/AuthController.java
@@ -6,18 +6,20 @@ import com.cheeeese.auth.dto.response.AuthReissueResponse;
 import com.cheeeese.auth.dto.response.AuthExchangeResponse;
 import com.cheeeese.auth.presentation.swagger.AuthSwagger;
 import com.cheeeese.global.common.CommonResponse;
+import com.cheeeese.global.security.jwt.JwtProvider;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
-import static com.cheeeese.global.common.code.SuccessCode.TOKEN_EXCHANGE_SUCCESS;
-import static com.cheeeese.global.common.code.SuccessCode.TOKEN_REISSUE_SUCCESS;
+import static com.cheeeese.global.common.code.SuccessCode.*;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/v1/auth")
 public class AuthController implements AuthSwagger {
 
+    private final JwtProvider jwtProvider;
     private final AuthService authService;
 
     @Override
@@ -30,5 +32,11 @@ public class AuthController implements AuthSwagger {
     @PostMapping("/reissue")
     public CommonResponse<AuthReissueResponse> reissueToken(@RequestBody @Valid AuthReissueRequest request) {
         return CommonResponse.success(TOKEN_REISSUE_SUCCESS, authService.reissueToken(request));
+    }
+
+    @PostMapping("/logout")
+    public CommonResponse<Void> logout(HttpServletRequest request) {
+        authService.logout(jwtProvider.resolveToken(request));
+        return CommonResponse.success(LOGOUT_SUCCESS);
     }
 }

--- a/src/main/java/com/cheeeese/auth/presentation/AuthController.java
+++ b/src/main/java/com/cheeeese/auth/presentation/AuthController.java
@@ -34,6 +34,7 @@ public class AuthController implements AuthSwagger {
         return CommonResponse.success(TOKEN_REISSUE_SUCCESS, authService.reissueToken(request));
     }
 
+    @Override
     @PostMapping("/logout")
     public CommonResponse<Void> logout(HttpServletRequest request) {
         authService.logout(jwtProvider.resolveToken(request));

--- a/src/main/java/com/cheeeese/auth/presentation/swagger/AuthSwagger.java
+++ b/src/main/java/com/cheeeese/auth/presentation/swagger/AuthSwagger.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -49,4 +50,16 @@ public interface AuthSwagger {
     CommonResponse<AuthReissueResponse> reissueToken(
             @RequestBody @Valid AuthReissueRequest request
     );
+
+    @Operation(
+            summary = "사용자 로그아웃 API",
+            description = "사용자 로그아웃을 진행합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "사용자 로그아웃이 성공적으로 실행되었습니다."
+            )
+    })
+    CommonResponse<Void> logout(HttpServletRequest request);
 }

--- a/src/main/java/com/cheeeese/global/common/code/SuccessCode.java
+++ b/src/main/java/com/cheeeese/global/common/code/SuccessCode.java
@@ -14,6 +14,7 @@ public enum SuccessCode implements BaseCode {
     // auth
     TOKEN_EXCHANGE_SUCCESS(HttpStatus.OK, "Token Exchange Success"),
     TOKEN_REISSUE_SUCCESS(HttpStatus.OK, "Token Reissue Success"),
+    LOGOUT_SUCCESS(HttpStatus.OK, "Logout Success"),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/cheeeese/global/security/handler/TokenBlacklistHandler.java
+++ b/src/main/java/com/cheeeese/global/security/handler/TokenBlacklistHandler.java
@@ -1,0 +1,26 @@
+package com.cheeeese.global.security.handler;
+
+import com.cheeeese.auth.exception.code.AuthErrorCode;
+import com.cheeeese.global.common.CommonResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class TokenBlacklistHandler {
+
+    private final ObjectMapper objectMapper;
+
+    public void handleBlacklistedToken(HttpServletResponse response) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json;charset=UTF-8");
+
+        CommonResponse<Void> errorResponse = CommonResponse.failure(AuthErrorCode.LOGGED_OUT_TOKEN);
+
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}

--- a/src/main/java/com/cheeeese/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/cheeeese/global/security/jwt/JwtAuthenticationFilter.java
@@ -1,5 +1,6 @@
 package com.cheeeese.global.security.jwt;
 
+import com.cheeeese.auth.application.TokenBlackListService;
 import com.cheeeese.global.security.CustomUserDetailService;
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
@@ -21,6 +22,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtProvider jwtProvider;
     private final CustomUserDetailService customUserDetailService;
+    private final TokenBlackListService tokenBlackListService;
 
     @Override
     protected void doFilterInternal(
@@ -30,9 +32,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     ) throws ServletException, IOException {
         String token = jwtProvider.resolveToken(request);
 
-        // TODO: 로그아웃 구현 후 관련 로직 추가
-
         if (token != null && jwtProvider.validateToken(token)) {
+            if (tokenBlackListService.isBlackListed(token)) {
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                response.setContentType("application/json;charset=UTF-8");
+                response.getWriter().write("{\"error\": \"로그아웃된 토큰입니다.\"}");
+                return;
+            }
             Claims claims = jwtProvider.getClaims(token);
             String userId = claims.getSubject();
 

--- a/src/main/java/com/cheeeese/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/cheeeese/global/security/jwt/JwtAuthenticationFilter.java
@@ -1,7 +1,8 @@
 package com.cheeeese.global.security.jwt;
 
-import com.cheeeese.auth.application.TokenBlackListService;
+import com.cheeeese.auth.application.TokenBlacklistService;
 import com.cheeeese.global.security.CustomUserDetailService;
+import com.cheeeese.global.security.handler.TokenBlacklistHandler;
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -22,7 +23,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtProvider jwtProvider;
     private final CustomUserDetailService customUserDetailService;
-    private final TokenBlackListService tokenBlackListService;
+    private final TokenBlacklistService tokenBlacklistService;
+    private final TokenBlacklistHandler tokenBlacklistHandler;
 
     @Override
     protected void doFilterInternal(
@@ -33,10 +35,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String token = jwtProvider.resolveToken(request);
 
         if (token != null && jwtProvider.validateToken(token)) {
-            if (tokenBlackListService.isBlackListed(token)) {
-                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-                response.setContentType("application/json;charset=UTF-8");
-                response.getWriter().write("{\"error\": \"로그아웃된 토큰입니다.\"}");
+            if (tokenBlacklistService.isBlackListed(token)) {
+                tokenBlacklistHandler.handleBlacklistedToken(response);
                 return;
             }
             Claims claims = jwtProvider.getClaims(token);


### PR DESCRIPTION
## 🔗 연관된 이슈
- #8

## 🚀 변경 유형
- [x] ✨ 기능 추가 (feature)
- [ ] 🐛 버그 수정 (fix)
- [ ] 📝 문서 변경 (docs)
- [ ] ♻️ 리팩토링 (refactor)
- [ ] 🧪 테스트 추가 / 수정 (test)
- [ ] ⚙️ 설정 변경 (chore)

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 사용자 로그아웃 기능 구현

## 📸 스크린샷
> 로그아웃 성공
<img width="515" height="332" alt="image" src="https://github.com/user-attachments/assets/aaf30ae5-8f23-4dce-96d5-56750a04be16" />

> 이미 로그아웃된 토큰일 경우
<img width="653" height="355" alt="image" src="https://github.com/user-attachments/assets/a07dcc59-9501-4480-8a72-b18b8bab05a3" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * 로그아웃 API 추가(POST /v1/auth/logout). 액세스 토큰을 즉시 무효화하고 연동 토큰을 정리합니다.
  * 토큰 블랙리스트 도입으로 로그아웃된 토큰 사용 시 401과 명확한 오류 메시지 반환.
  * LOGOUT_SUCCESS 성공 코드로 일관된 응답 제공.
* Documentation
  * Swagger에 로그아웃 엔드포인트 문서화.
* Refactor
  * 리프레시 토큰 검증을 보조 메서드로 분리해 조회·검증 흐름을 정돈.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->