### PR TITLE
feat: 사용자 온보딩 구현

### DIFF
--- a/src/main/java/com/cheeeese/CheeeeseApplication.java
+++ b/src/main/java/com/cheeeese/CheeeeseApplication.java
@@ -7,7 +7,7 @@ import org.springframework.data.redis.repository.configuration.EnableRedisReposi
 
 @SpringBootApplication
 @EnableJpaAuditing
-@EnableRedisRepositories(basePackages = "com.cheeeese.oauth2.infrastructure.persistence")
+@EnableRedisRepositories(basePackages = "com.cheeeese.auth.infrastructure.persistence")
 public class CheeeeseApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/cheeeese/global/common/code/SuccessCode.java
+++ b/src/main/java/com/cheeeese/global/common/code/SuccessCode.java
@@ -18,7 +18,7 @@ public enum SuccessCode implements BaseCode {
 
     // user
     USER_ONBOARDING_SUCCESS(HttpStatus.OK, "User Onboarding Success"),
-    USER_AGREEMENT_SUCCESS(HttpStatus.OK, "User Agreement Success"),
+    USER_AGREEMENT_ACCEPT_SUCCESS(HttpStatus.OK, "User Agreement Accept Success"),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/cheeeese/global/common/code/SuccessCode.java
+++ b/src/main/java/com/cheeeese/global/common/code/SuccessCode.java
@@ -17,7 +17,7 @@ public enum SuccessCode implements BaseCode {
     LOGOUT_SUCCESS(HttpStatus.OK, "Logout Success"),
 
     // user
-    USER_ONBOARDING_SUCCESS(HttpStatus.OK, "User Onboarding Success"),
+    USER_PROFILE_UPDATE_SUCCESS(HttpStatus.OK, "User Profile Update Success"),
     USER_AGREEMENT_ACCEPT_SUCCESS(HttpStatus.OK, "User Agreement Accept Success"),
     ;
 

--- a/src/main/java/com/cheeeese/global/common/code/SuccessCode.java
+++ b/src/main/java/com/cheeeese/global/common/code/SuccessCode.java
@@ -18,6 +18,7 @@ public enum SuccessCode implements BaseCode {
 
     // user
     USER_ONBOARDING_SUCCESS(HttpStatus.OK, "User Onboarding Success"),
+    USER_AGREEMENT_SUCCESS(HttpStatus.OK, "User Agreement Success"),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/cheeeese/global/common/code/SuccessCode.java
+++ b/src/main/java/com/cheeeese/global/common/code/SuccessCode.java
@@ -15,6 +15,9 @@ public enum SuccessCode implements BaseCode {
     TOKEN_EXCHANGE_SUCCESS(HttpStatus.OK, "Token Exchange Success"),
     TOKEN_REISSUE_SUCCESS(HttpStatus.OK, "Token Reissue Success"),
     LOGOUT_SUCCESS(HttpStatus.OK, "Logout Success"),
+
+    // user
+    USER_ONBOARDING_SUCCESS(HttpStatus.OK, "User Onboarding Success"),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/cheeeese/oauth2/infrastructure/userinfo/KakaoUserInfo.java
+++ b/src/main/java/com/cheeeese/oauth2/infrastructure/userinfo/KakaoUserInfo.java
@@ -42,7 +42,8 @@ public class KakaoUserInfo implements OAuth2UserInfo {
 
     @SuppressWarnings("unchecked")
     private Map<String, Object> getKakaoProfile() {
-        Object profile = attributes.get("profile");
+        Map<String, Object> kakaoAccount = getKakaoAccount();
+        Object profile = kakaoAccount.get("profile");
         if (profile instanceof Map) {
             return (Map<String, Object>) profile;
         }

--- a/src/main/java/com/cheeeese/user/application/UserService.java
+++ b/src/main/java/com/cheeeese/user/application/UserService.java
@@ -17,6 +17,7 @@ public class UserService {
 
     @Transactional
     public void updateUserProfile(User user, UserProfileRequest request) {
+        // TODO: 이미지 수정 추후 추가
         user.updateUserProfile(request.name());
     }
 

--- a/src/main/java/com/cheeeese/user/application/UserService.java
+++ b/src/main/java/com/cheeeese/user/application/UserService.java
@@ -26,8 +26,8 @@ public class UserService {
         userValidator.validateUserAgreement(request);
 
         user.saveUserAgreement(
-                true,
-                true,
+                request.isServiceAgreement(),
+                request.isUserInfoAgreement(),
                 request.isMarketingAgreement(),
                 request.isThirdPartyAgreement()
         );

--- a/src/main/java/com/cheeeese/user/application/UserService.java
+++ b/src/main/java/com/cheeeese/user/application/UserService.java
@@ -1,5 +1,6 @@
 package com.cheeeese.user.application;
 
+import com.cheeeese.user.application.validator.UserValidator;
 import com.cheeeese.user.domain.User;
 import com.cheeeese.user.dto.request.UserAgreementRequest;
 import com.cheeeese.user.dto.request.UserProfileRequest;
@@ -13,7 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class UserService {
 
-    private final UserRepository userRepository;
+    private final UserValidator userValidator;
 
     @Transactional
     public void updateUserProfile(User user, UserProfileRequest request) {
@@ -22,6 +23,8 @@ public class UserService {
 
     @Transactional
     public void saveUserAgreement(User user, UserAgreementRequest request) {
+        userValidator.validateUserAgreement(request);
+
         user.saveUserAgreement(
                 true,
                 true,

--- a/src/main/java/com/cheeeese/user/application/UserService.java
+++ b/src/main/java/com/cheeeese/user/application/UserService.java
@@ -2,7 +2,7 @@ package com.cheeeese.user.application;
 
 import com.cheeeese.user.domain.User;
 import com.cheeeese.user.dto.request.UserAgreementRequest;
-import com.cheeeese.user.dto.request.UserOnboardingRequest;
+import com.cheeeese.user.dto.request.UserProfileRequest;
 import com.cheeeese.user.infrastructure.persistence.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,8 +16,8 @@ public class UserService {
     private final UserRepository userRepository;
 
     @Transactional
-    public void saveUserOnboarding(User user, UserOnboardingRequest request) {
-        user.saveUserOnboarding(request.name());
+    public void updateUserProfile(User user, UserProfileRequest request) {
+        user.updateUserProfile(request.name());
     }
 
     @Transactional

--- a/src/main/java/com/cheeeese/user/application/UserService.java
+++ b/src/main/java/com/cheeeese/user/application/UserService.java
@@ -1,0 +1,21 @@
+package com.cheeeese.user.application;
+
+import com.cheeeese.user.domain.User;
+import com.cheeeese.user.dto.request.UserOnboardingRequest;
+import com.cheeeese.user.infrastructure.persistence.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void saveUserOnboarding(User user, UserOnboardingRequest request) {
+        user.saveUserOnboarding(request.name());
+    }
+}

--- a/src/main/java/com/cheeeese/user/application/UserService.java
+++ b/src/main/java/com/cheeeese/user/application/UserService.java
@@ -1,6 +1,7 @@
 package com.cheeeese.user.application;
 
 import com.cheeeese.user.domain.User;
+import com.cheeeese.user.dto.request.UserAgreementRequest;
 import com.cheeeese.user.dto.request.UserOnboardingRequest;
 import com.cheeeese.user.infrastructure.persistence.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -17,5 +18,15 @@ public class UserService {
     @Transactional
     public void saveUserOnboarding(User user, UserOnboardingRequest request) {
         user.saveUserOnboarding(request.name());
+    }
+
+    @Transactional
+    public void saveUserAgreement(User user, UserAgreementRequest request) {
+        user.saveUserAgreement(
+                true,
+                true,
+                request.isMarketingAgreement(),
+                request.isThirdPartyAgreement()
+        );
     }
 }

--- a/src/main/java/com/cheeeese/user/application/UserService.java
+++ b/src/main/java/com/cheeeese/user/application/UserService.java
@@ -4,7 +4,6 @@ import com.cheeeese.user.application.validator.UserValidator;
 import com.cheeeese.user.domain.User;
 import com.cheeeese.user.dto.request.UserAgreementRequest;
 import com.cheeeese.user.dto.request.UserProfileRequest;
-import com.cheeeese.user.infrastructure.persistence.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/com/cheeeese/user/application/validator/UserValidator.java
+++ b/src/main/java/com/cheeeese/user/application/validator/UserValidator.java
@@ -1,0 +1,16 @@
+package com.cheeeese.user.application.validator;
+
+import com.cheeeese.user.dto.request.UserAgreementRequest;
+import com.cheeeese.user.exception.UserException;
+import com.cheeeese.user.exception.code.UserErrorCode;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserValidator {
+
+    public void validateUserAgreement(UserAgreementRequest request) {
+        if (!request.isServiceAgreement() || !request.isUserInfoAgreement()) {
+            throw new UserException(UserErrorCode.REQUIRED_TERMS_NOT_AGREED);
+        }
+    }
+}

--- a/src/main/java/com/cheeeese/user/domain/User.java
+++ b/src/main/java/com/cheeeese/user/domain/User.java
@@ -23,31 +23,31 @@ public class User extends BaseEntity {
     @Column(name = "email", nullable = false, unique = true)
     private String email;
 
-    @Column(name = "profile_image")
+    @Column(name = "profile_image", nullable = false)
     private String profileImage;
 
     @Column(name = "provider_id", nullable = false)
     private String providerId;
 
-    @Column(name = "is_service_agreement")
-    private Boolean isServiceAgreement;
+    @Column(name = "is_service_agreement", nullable = false)
+    private boolean isServiceAgreement;
 
-    @Column(name = "is_user_info_agreement")
-    private Boolean isUserInfoAgreement;
+    @Column(name = "is_user_info_agreement", nullable = false)
+    private boolean isUserInfoAgreement;
 
-    @Column(name = "is_marketing_agreement")
-    private Boolean isMarketingAgreement;
+    @Column(name = "is_marketing_agreement", nullable = false)
+    private boolean isMarketingAgreement;
 
-    @Column(name = "is_third_party_agreement")
-    private Boolean isThirdPartyAgreement;
+    @Column(name = "is_third_party_agreement", nullable = false)
+    private boolean isThirdPartyAgreement;
 
-    @Column(name = "album_cnt")
+    @Column(name = "album_cnt", nullable = false)
     private int albumCnt;
 
-    @Column(name = "photo_cnt")
+    @Column(name = "photo_cnt", nullable = false)
     private int photoCnt;
 
-    @Column(name = "likes_cnt")
+    @Column(name = "likes_cnt", nullable = false)
     private int likesCnt;
 
     @Builder
@@ -56,10 +56,10 @@ public class User extends BaseEntity {
             String email,
             String profileImage,
             String providerId,
-            Boolean isServiceAgreement,
-            Boolean isUserInfoAgreement,
-            Boolean isMarketingAgreement,
-            Boolean isThirdPartyAgreement,
+            boolean isServiceAgreement,
+            boolean isUserInfoAgreement,
+            boolean isMarketingAgreement,
+            boolean isThirdPartyAgreement,
             int albumCnt,
             int photoCnt,
             int likesCnt
@@ -82,10 +82,10 @@ public class User extends BaseEntity {
     }
 
     public void saveUserAgreement(
-            Boolean isServiceAgreement,
-            Boolean isUserInfoAgreement,
-            Boolean isMarketingAgreement,
-            Boolean isThirdPartyAgreement
+            boolean isServiceAgreement,
+            boolean isUserInfoAgreement,
+            boolean isMarketingAgreement,
+            boolean isThirdPartyAgreement
     ) {
         this.isServiceAgreement = isServiceAgreement;
         this.isUserInfoAgreement = isUserInfoAgreement;

--- a/src/main/java/com/cheeeese/user/domain/User.java
+++ b/src/main/java/com/cheeeese/user/domain/User.java
@@ -80,4 +80,16 @@ public class User extends BaseEntity {
     public void saveUserOnboarding(String name) {
         this.name = name;
     }
+
+    public void saveUserAgreement(
+            boolean isServiceAgreement,
+            boolean isUserInfoAgreement,
+            boolean isMarketingAgreement,
+            boolean isThirdPartyAgreement
+    ) {
+        this.isServiceAgreement = isServiceAgreement;
+        this.isUserInfoAgreement = isUserInfoAgreement;
+        this.isMarketingAgreement = isMarketingAgreement;
+        this.isThirdPartyAgreement = isThirdPartyAgreement;
+    }
 }

--- a/src/main/java/com/cheeeese/user/domain/User.java
+++ b/src/main/java/com/cheeeese/user/domain/User.java
@@ -82,10 +82,10 @@ public class User extends BaseEntity {
     }
 
     public void saveUserAgreement(
-            boolean isServiceAgreement,
-            boolean isUserInfoAgreement,
-            boolean isMarketingAgreement,
-            boolean isThirdPartyAgreement
+            Boolean isServiceAgreement,
+            Boolean isUserInfoAgreement,
+            Boolean isMarketingAgreement,
+            Boolean isThirdPartyAgreement
     ) {
         this.isServiceAgreement = isServiceAgreement;
         this.isUserInfoAgreement = isUserInfoAgreement;

--- a/src/main/java/com/cheeeese/user/domain/User.java
+++ b/src/main/java/com/cheeeese/user/domain/User.java
@@ -76,4 +76,8 @@ public class User extends BaseEntity {
         this.photoCnt = photoCnt;
         this.likesCnt = likesCnt;
     }
+
+    public void saveUserOnboarding(String name) {
+        this.name = name;
+    }
 }

--- a/src/main/java/com/cheeeese/user/domain/User.java
+++ b/src/main/java/com/cheeeese/user/domain/User.java
@@ -77,7 +77,7 @@ public class User extends BaseEntity {
         this.likesCnt = likesCnt;
     }
 
-    public void saveUserOnboarding(String name) {
+    public void updateUserProfile(String name) {
         this.name = name;
     }
 

--- a/src/main/java/com/cheeeese/user/dto/request/UserAgreementRequest.java
+++ b/src/main/java/com/cheeeese/user/dto/request/UserAgreementRequest.java
@@ -1,17 +1,20 @@
 package com.cheeeese.user.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 
 @Builder
 @Schema(description = "사용자 이용 약관 API")
 public record UserAgreementRequest(
+        @NotNull
         @Schema(
                 description = "서비스 이용 약관 동의",
                 example = "true"
         )
         Boolean isServiceAgreement,
 
+        @NotNull
         @Schema(
                 description = "사용자 정보 수집 동의",
                 example = "true"

--- a/src/main/java/com/cheeeese/user/dto/request/UserAgreementRequest.java
+++ b/src/main/java/com/cheeeese/user/dto/request/UserAgreementRequest.java
@@ -12,25 +12,25 @@ public record UserAgreementRequest(
                 description = "서비스 이용 약관 동의",
                 example = "true"
         )
-        Boolean isServiceAgreement,
+        boolean isServiceAgreement,
 
         @NotNull
         @Schema(
                 description = "사용자 정보 수집 동의",
                 example = "true"
         )
-        Boolean isUserInfoAgreement,
+        boolean isUserInfoAgreement,
 
         @Schema(
                 description = "마케팅 수신 동의",
                 example = "false"
         )
-        Boolean isMarketingAgreement,
+        boolean isMarketingAgreement,
 
         @Schema(
                 description = "제3자 제공 동의",
                 example = "false"
         )
-        Boolean isThirdPartyAgreement
+        boolean isThirdPartyAgreement
 ) {
 }

--- a/src/main/java/com/cheeeese/user/dto/request/UserAgreementRequest.java
+++ b/src/main/java/com/cheeeese/user/dto/request/UserAgreementRequest.java
@@ -1,0 +1,12 @@
+package com.cheeeese.user.dto.request;
+
+import lombok.Builder;
+
+@Builder
+public record UserAgreementRequest(
+        boolean isServiceAgreement,
+        boolean isUserInfoAgreement,
+        boolean isMarketingAgreement,
+        boolean isThirdPartyAgreement
+) {
+}

--- a/src/main/java/com/cheeeese/user/dto/request/UserAgreementRequest.java
+++ b/src/main/java/com/cheeeese/user/dto/request/UserAgreementRequest.java
@@ -1,12 +1,33 @@
 package com.cheeeese.user.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder
+@Schema(description = "사용자 이용 약관 API")
 public record UserAgreementRequest(
-        boolean isServiceAgreement,
-        boolean isUserInfoAgreement,
-        boolean isMarketingAgreement,
-        boolean isThirdPartyAgreement
+        @Schema(
+                description = "서비스 이용 약관 동의",
+                example = "true"
+        )
+        Boolean isServiceAgreement,
+
+        @Schema(
+                description = "사용자 정보 수집 동의",
+                example = "true"
+        )
+        Boolean isUserInfoAgreement,
+
+        @Schema(
+                description = "마케팅 수신 동의",
+                example = "false"
+        )
+        Boolean isMarketingAgreement,
+
+        @Schema(
+                description = "제3자 제공 동의",
+                example = "false"
+        )
+        Boolean isThirdPartyAgreement
 ) {
 }

--- a/src/main/java/com/cheeeese/user/dto/request/UserOnboardingRequest.java
+++ b/src/main/java/com/cheeeese/user/dto/request/UserOnboardingRequest.java
@@ -1,0 +1,9 @@
+package com.cheeeese.user.dto.request;
+
+import lombok.Builder;
+
+@Builder
+public record UserOnboardingRequest(
+        String name
+) {
+}

--- a/src/main/java/com/cheeeese/user/dto/request/UserProfileRequest.java
+++ b/src/main/java/com/cheeeese/user/dto/request/UserProfileRequest.java
@@ -1,9 +1,12 @@
 package com.cheeeese.user.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder
+@Schema(description = "사용자 프로필 수정 API")
 public record UserProfileRequest(
+        @Schema(description = "사용자 이름", example = "주")
         String name
 ) {
 }

--- a/src/main/java/com/cheeeese/user/dto/request/UserProfileRequest.java
+++ b/src/main/java/com/cheeeese/user/dto/request/UserProfileRequest.java
@@ -3,7 +3,7 @@ package com.cheeeese.user.dto.request;
 import lombok.Builder;
 
 @Builder
-public record UserOnboardingRequest(
+public record UserProfileRequest(
         String name
 ) {
 }

--- a/src/main/java/com/cheeeese/user/dto/request/UserProfileRequest.java
+++ b/src/main/java/com/cheeeese/user/dto/request/UserProfileRequest.java
@@ -8,5 +8,6 @@ import lombok.Builder;
 public record UserProfileRequest(
         @Schema(description = "사용자 이름", example = "주")
         String name
+        // TODO: 이미지 수정 추후 추가
 ) {
 }

--- a/src/main/java/com/cheeeese/user/exception/code/UserErrorCode.java
+++ b/src/main/java/com/cheeeese/user/exception/code/UserErrorCode.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 public enum UserErrorCode implements BaseCode {
 
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다."),
+    REQUIRED_TERMS_NOT_AGREED(HttpStatus.BAD_REQUEST, "필수 약관에 동의하지 않았습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/cheeeese/user/presentation/UserController.java
+++ b/src/main/java/com/cheeeese/user/presentation/UserController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import static com.cheeeese.global.common.code.SuccessCode.USER_AGREEMENT_SUCCESS;
+import static com.cheeeese.global.common.code.SuccessCode.USER_AGREEMENT_ACCEPT_SUCCESS;
 import static com.cheeeese.global.common.code.SuccessCode.USER_ONBOARDING_SUCCESS;
 
 @RestController
@@ -38,6 +38,6 @@ public class UserController {
             @RequestBody @Valid UserAgreementRequest request
     ) {
         userService.saveUserAgreement(user, request);
-        return CommonResponse.success(USER_AGREEMENT_SUCCESS);
+        return CommonResponse.success(USER_AGREEMENT_ACCEPT_SUCCESS);
     }
 }

--- a/src/main/java/com/cheeeese/user/presentation/UserController.java
+++ b/src/main/java/com/cheeeese/user/presentation/UserController.java
@@ -10,6 +10,7 @@ import com.cheeeese.user.presentation.swagger.UserSwagger;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -25,7 +26,7 @@ public class UserController implements UserSwagger {
     private final UserService userService;
 
     @Override
-    @PostMapping("/me/profile")
+    @PatchMapping("/me/profile")
     public CommonResponse<Void> updateUserProfile(
             @CurrentUser User user,
             @RequestBody @Valid UserProfileRequest request

--- a/src/main/java/com/cheeeese/user/presentation/UserController.java
+++ b/src/main/java/com/cheeeese/user/presentation/UserController.java
@@ -7,13 +7,9 @@ import com.cheeeese.user.domain.User;
 import com.cheeeese.user.dto.request.UserAgreementRequest;
 import com.cheeeese.user.dto.request.UserProfileRequest;
 import com.cheeeese.user.presentation.swagger.UserSwagger;
-import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import static com.cheeeese.global.common.code.SuccessCode.USER_AGREEMENT_ACCEPT_SUCCESS;
 import static com.cheeeese.global.common.code.SuccessCode.USER_PROFILE_UPDATE_SUCCESS;

--- a/src/main/java/com/cheeeese/user/presentation/UserController.java
+++ b/src/main/java/com/cheeeese/user/presentation/UserController.java
@@ -1,0 +1,32 @@
+package com.cheeeese.user.presentation;
+
+import com.cheeeese.global.common.CommonResponse;
+import com.cheeeese.global.util.CurrentUser;
+import com.cheeeese.user.application.UserService;
+import com.cheeeese.user.domain.User;
+import com.cheeeese.user.dto.request.UserOnboardingRequest;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.cheeeese.global.common.code.SuccessCode.USER_ONBOARDING_SUCCESS;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/user")
+public class UserController {
+
+    private final UserService userService;
+
+    @PostMapping("/onboarding")
+    public CommonResponse<Void> saveUserOnboarding(
+            @CurrentUser User user,
+            @RequestBody @Valid UserOnboardingRequest request
+    ) {
+        userService.saveUserOnboarding(user, request);
+        return CommonResponse.success(USER_ONBOARDING_SUCCESS);
+    }
+}

--- a/src/main/java/com/cheeeese/user/presentation/UserController.java
+++ b/src/main/java/com/cheeeese/user/presentation/UserController.java
@@ -5,7 +5,7 @@ import com.cheeeese.global.util.CurrentUser;
 import com.cheeeese.user.application.UserService;
 import com.cheeeese.user.domain.User;
 import com.cheeeese.user.dto.request.UserAgreementRequest;
-import com.cheeeese.user.dto.request.UserOnboardingRequest;
+import com.cheeeese.user.dto.request.UserProfileRequest;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import static com.cheeeese.global.common.code.SuccessCode.USER_AGREEMENT_ACCEPT_SUCCESS;
-import static com.cheeeese.global.common.code.SuccessCode.USER_ONBOARDING_SUCCESS;
+import static com.cheeeese.global.common.code.SuccessCode.USER_PROFILE_UPDATE_SUCCESS;
 
 @RestController
 @RequiredArgsConstructor
@@ -23,13 +23,13 @@ public class UserController {
 
     private final UserService userService;
 
-    @PostMapping("/onboarding")
-    public CommonResponse<Void> saveUserOnboarding(
+    @PostMapping("/me/profile")
+    public CommonResponse<Void> updateUserProfile(
             @CurrentUser User user,
-            @RequestBody @Valid UserOnboardingRequest request
+            @RequestBody @Valid UserProfileRequest request
     ) {
-        userService.saveUserOnboarding(user, request);
-        return CommonResponse.success(USER_ONBOARDING_SUCCESS);
+        userService.updateUserProfile(user, request);
+        return CommonResponse.success(USER_PROFILE_UPDATE_SUCCESS);
     }
 
     @PostMapping("/agreement")

--- a/src/main/java/com/cheeeese/user/presentation/UserController.java
+++ b/src/main/java/com/cheeeese/user/presentation/UserController.java
@@ -4,6 +4,7 @@ import com.cheeeese.global.common.CommonResponse;
 import com.cheeeese.global.util.CurrentUser;
 import com.cheeeese.user.application.UserService;
 import com.cheeeese.user.domain.User;
+import com.cheeeese.user.dto.request.UserAgreementRequest;
 import com.cheeeese.user.dto.request.UserOnboardingRequest;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import jakarta.validation.Valid;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import static com.cheeeese.global.common.code.SuccessCode.USER_AGREEMENT_SUCCESS;
 import static com.cheeeese.global.common.code.SuccessCode.USER_ONBOARDING_SUCCESS;
 
 @RestController
@@ -28,5 +30,14 @@ public class UserController {
     ) {
         userService.saveUserOnboarding(user, request);
         return CommonResponse.success(USER_ONBOARDING_SUCCESS);
+    }
+
+    @PostMapping("/agreement")
+    public CommonResponse<Void> saveUserAgreement(
+            @CurrentUser User user,
+            @RequestBody @Valid UserAgreementRequest request
+    ) {
+        userService.saveUserAgreement(user, request);
+        return CommonResponse.success(USER_AGREEMENT_SUCCESS);
     }
 }

--- a/src/main/java/com/cheeeese/user/presentation/UserController.java
+++ b/src/main/java/com/cheeeese/user/presentation/UserController.java
@@ -6,6 +6,7 @@ import com.cheeeese.user.application.UserService;
 import com.cheeeese.user.domain.User;
 import com.cheeeese.user.dto.request.UserAgreementRequest;
 import com.cheeeese.user.dto.request.UserProfileRequest;
+import com.cheeeese.user.presentation.swagger.UserSwagger;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -19,10 +20,11 @@ import static com.cheeeese.global.common.code.SuccessCode.USER_PROFILE_UPDATE_SU
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/v1/user")
-public class UserController {
+public class UserController implements UserSwagger {
 
     private final UserService userService;
 
+    @Override
     @PostMapping("/me/profile")
     public CommonResponse<Void> updateUserProfile(
             @CurrentUser User user,
@@ -32,6 +34,7 @@ public class UserController {
         return CommonResponse.success(USER_PROFILE_UPDATE_SUCCESS);
     }
 
+    @Override
     @PostMapping("/agreement")
     public CommonResponse<Void> saveUserAgreement(
             @CurrentUser User user,

--- a/src/main/java/com/cheeeese/user/presentation/swagger/UserSwagger.java
+++ b/src/main/java/com/cheeeese/user/presentation/swagger/UserSwagger.java
@@ -19,7 +19,7 @@ public interface UserSwagger {
             description = """
                           ### RequestBody
                           ---
-                          `name`: 사용자 이름
+                          `name`: 사용자 이름 (String)
                           """
     )
     @ApiResponses(value = {
@@ -41,7 +41,7 @@ public interface UserSwagger {
                           `isServiceAgreement`: 서비스 이용 약관 동의 (boolean) \n
                           `isUserInfoAgreement`: 사용자 정보 수집 동의 (boolean) \n
                           `isMarketingAgreement`: 마케팅 수신 동의 (boolean) \n
-                          `isThirdPartyAgreement`: 제3자 제공 동의
+                          `isThirdPartyAgreement`: 제3자 제공 동의 (boolean)
                           """
     )
     @ApiResponses(value = {

--- a/src/main/java/com/cheeeese/user/presentation/swagger/UserSwagger.java
+++ b/src/main/java/com/cheeeese/user/presentation/swagger/UserSwagger.java
@@ -1,0 +1,57 @@
+package com.cheeeese.user.presentation.swagger;
+
+import com.cheeeese.global.common.CommonResponse;
+import com.cheeeese.global.util.CurrentUser;
+import com.cheeeese.user.domain.User;
+import com.cheeeese.user.dto.request.UserAgreementRequest;
+import com.cheeeese.user.dto.request.UserProfileRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+
+@Tag(name = "[사용자]", description = "사용자 관련 API")
+public interface UserSwagger {
+    @Operation(
+            summary = "사용자 프로필 수정 API",
+            description = """
+                          ### RequestBody
+                          ---
+                          `name`: 사용자 이름
+                          """
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "사용자 프로필이 성공적으로 수정되었습니다."
+            )
+    })
+    CommonResponse<Void> updateUserProfile(
+            @CurrentUser User user,
+            @RequestBody @Valid UserProfileRequest request
+    );
+
+    @Operation(
+            summary = "사용자 이용 약관 동의 API",
+            description = """
+                          ### RequestBody
+                          ---
+                          `isServiceAgreement`: 서비스 이용 약관 동의 (boolean) \n
+                          `isUserInfoAgreement`: 사용자 정보 수집 동의 (boolean) \n
+                          `isMarketingAgreement`: 마케팅 수신 동의 (boolean) \n
+                          `isThirdPartyAgreement`: 제3자 제공 동의
+                          """
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "사용자 이용 약관 동의가 성공적으로 실행되었습니다."
+            )
+    })
+    CommonResponse<Void> saveUserAgreement(
+            @CurrentUser User user,
+            @RequestBody @Valid UserAgreementRequest request
+    );
+}

--- a/src/main/java/com/cheeeese/user/presentation/swagger/UserSwagger.java
+++ b/src/main/java/com/cheeeese/user/presentation/swagger/UserSwagger.java
@@ -6,11 +6,11 @@ import com.cheeeese.user.domain.User;
 import com.cheeeese.user.dto.request.UserAgreementRequest;
 import com.cheeeese.user.dto.request.UserProfileRequest;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "[사용자]", description = "사용자 관련 API")
 public interface UserSwagger {


### PR DESCRIPTION
## 🔗 연관된 이슈
- #10

## 🚀 변경 유형
- [x] ✨ 기능 추가 (feature)
- [ ] 🐛 버그 수정 (fix)
- [ ] 📝 문서 변경 (docs)
- [ ] ♻️ 리팩토링 (refactor)
- [ ] 🧪 테스트 추가 / 수정 (test)
- [ ] ⚙️ 설정 변경 (chore)

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 사용자 프로필 수정 API
- 사용자 이용 약관 API

## 📸 스크린샷
> 사용자 프로필 수정 API
<img width="607" height="323" alt="image" src="https://github.com/user-attachments/assets/2c5dedec-a0b5-42f8-b7b8-e52def73c08a" />

> 사용자 이용 약관 API
<img width="523" height="326" alt="image" src="https://github.com/user-attachments/assets/a996652c-e193-43b1-b740-e43618a92577" />

> 필수 약관에 동의하지 않았을 경우
<img width="597" height="453" alt="image" src="https://github.com/user-attachments/assets/999062e0-bbcd-49b1-bfca-07866357e439" />

## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
- 사용자 온보딩이 사실상 프로필 수정 느낌이길래 걍 아예 통합해서 사용자 프로필 수정 API로 햇습니다
- 사진 수정은 네이버가 일하면 추가할게요ㅠ.ㅠ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 사용자 프로필 수정 API 추가: PATCH /v1/user/me/profile (이름 변경 지원)
  - 약관 동의 API 추가: POST /v1/user/agreement (서비스/개인정보 필수 및 마케팅/제3자 선택 동의 수집)
  - 성공 응답 코드 추가: 프로필 수정 성공, 약관 동의 성공

- **Bug Fixes**
  - 카카오 프로필 조회 로직 개선으로 프로필 정보 안정성 향상

- **Documentation**
  - 신규 사용자 API에 대한 Swagger 문서 추가(요청/응답 스펙, 예시 포함)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->