### PR TITLE
chore: 서버 배포 및 cicd 워크플로우 구축

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -61,6 +61,7 @@ jobs:
             key: ${{ secrets.SERVER_SSH_KEY }}
             source: ./src/main/resources/secret/prod.env
             target: /root
+            strip_components: 4
 
         - name: Copy dev.env to NCP server
           uses: appleboy/scp-action@master
@@ -70,6 +71,7 @@ jobs:
             key: ${{ secrets.SERVER_SSH_KEY }}
             source: ./src/main/resources/secret/dev.env
             target: /root
+            strip_components: 4
 
         - name: Copy deploy.sh to NCP server
           uses: appleboy/scp-action@master
@@ -79,6 +81,7 @@ jobs:
             key: ${{ secrets.SERVER_SSH_KEY }}
             source: ./src/main/resources/secret/deploy.sh
             target: /root
+            strip_components: 4
 
         - name: Copy docker-compose.yml to NCP server
           uses: appleboy/scp-action@master
@@ -89,7 +92,7 @@ jobs:
             source: ./docker-compose.yml
             target: /root
 
-        # ---------------------- PROD Deployment ----------------------
+      # ---------------------- PROD Deployment ----------------------
         - name: Docker build & push (prod)
           if: github.ref == 'refs/heads/main'
           run: |

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -46,23 +46,11 @@ jobs:
             chmod 600 ./src/main/resources/secret/deploy.sh
             echo "✅ .env & .sh 파일 생성 완료"
         
-
         - name: Docker Login
           uses: docker/login-action@v3
           with:
             username: ${{ secrets.DOCKERHUB_USERNAME }}
             password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-        - name: 🧾 Check generated secret files
-          run: |
-            echo "=== Checking secret directory ==="
-            ls -al ./src/main/resources/secret || echo "❌ secret folder not found"
-            echo "=== Check file content ==="
-            cat ./src/main/resources/secret/prod.env || echo "❌ prod.env missing"
-            cat ./src/main/resources/secret/dev.env || echo "❌ dev.env missing"
-            cat ./src/main/resources/secret/deploy.sh || echo "❌ deploy.sh missing"
-            echo "=== Check docker-compose existence ==="
-            ls -al ./docker-compose.yml || echo "❌ docker-compose.yml missing"
 
         - name: Copy deployment files to NCP server (Integrated SCP)
           uses: appleboy/scp-action@master
@@ -70,12 +58,12 @@ jobs:
             host: ${{ secrets.SERVER_HOST }}
             username: ${{ secrets.SERVER_USER }}
             key: ${{ secrets.SERVER_SSH_KEY }}
-            source: |
-              ./src/main/resources/secret/prod.env
-              ./src/main/resources/secret/dev.env
-              ./src/main/resources/secret/deploy.sh
-              ./docker-compose.yml
             target: /root
+            source: >
+              src/main/resources/secret/prod.env
+              src/main/resources/secret/dev.env
+              src/main/resources/secret/deploy.sh
+              docker-compose.yml
 
         # ---------------------- PROD Deployment ----------------------
         - name: Docker build & push (prod)

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -53,6 +53,17 @@ jobs:
             username: ${{ secrets.DOCKERHUB_USERNAME }}
             password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+        - name: 🧾 Check generated secret files
+          run: |
+            echo "=== Checking secret directory ==="
+            ls -al ./src/main/resources/secret || echo "❌ secret folder not found"
+            echo "=== Check file content ==="
+            cat ./src/main/resources/secret/prod.env || echo "❌ prod.env missing"
+            cat ./src/main/resources/secret/dev.env || echo "❌ dev.env missing"
+            cat ./src/main/resources/secret/deploy.sh || echo "❌ deploy.sh missing"
+            echo "=== Check docker-compose existence ==="
+            ls -al ./docker-compose.yml || echo "❌ docker-compose.yml missing"
+
         - name: Copy deployment files to NCP server (Integrated SCP)
           uses: appleboy/scp-action@master
           with:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -2,7 +2,7 @@ name: CI/CD Workflow
 
 on:
   push:
-    branches: [ "main", "develop"]
+    branches: [ "main", "develop", "chore/#4-cicd"]
 
 jobs:
   CI-CD:
@@ -126,7 +126,7 @@ jobs:
 
         # ---------------------- DEV Deployment ----------------------
         - name: Docker build & push (develop)
-          if: github.ref == 'refs/heads/develop'
+          if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/chore/#4-cicd'
           run: |
             IMAGE_NAME=${{ secrets.DOCKER_REPO }}/${{ secrets.DOCKER_IMAGE_NAME }}
             
@@ -138,7 +138,7 @@ jobs:
             echo "✅ Pushed $IMAGE_NAME:dev"
 
         - name: Deploy to develop
-          if: github.ref == 'refs/heads/develop'
+          if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/chore/#4-cicd'
           uses: appleboy/ssh-action@master
           with:
             host: ${{ secrets.SERVER_HOST }}

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -45,25 +45,49 @@ jobs:
             chmod 600 ./src/main/resources/secret/*.env
             chmod 600 ./src/main/resources/secret/deploy.sh
             echo "✅ .env & .sh 파일 생성 완료"
-        
+
         - name: Docker Login
           uses: docker/login-action@v3
           with:
             username: ${{ secrets.DOCKERHUB_USERNAME }}
             password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-        - name: Copy deployment files to NCP server (Integrated SCP)
+        # ------------------ 파일별 개별 전송 ------------------
+        - name: Copy prod.env to NCP server
           uses: appleboy/scp-action@master
           with:
             host: ${{ secrets.SERVER_HOST }}
             username: ${{ secrets.SERVER_USER }}
             key: ${{ secrets.SERVER_SSH_KEY }}
+            source: ./src/main/resources/secret/prod.env
             target: /root
-            source: >
-              src/main/resources/secret/prod.env
-              src/main/resources/secret/dev.env
-              src/main/resources/secret/deploy.sh
-              docker-compose.yml
+
+        - name: Copy dev.env to NCP server
+          uses: appleboy/scp-action@master
+          with:
+            host: ${{ secrets.SERVER_HOST }}
+            username: ${{ secrets.SERVER_USER }}
+            key: ${{ secrets.SERVER_SSH_KEY }}
+            source: ./src/main/resources/secret/dev.env
+            target: /root
+
+        - name: Copy deploy.sh to NCP server
+          uses: appleboy/scp-action@master
+          with:
+            host: ${{ secrets.SERVER_HOST }}
+            username: ${{ secrets.SERVER_USER }}
+            key: ${{ secrets.SERVER_SSH_KEY }}
+            source: ./src/main/resources/secret/deploy.sh
+            target: /root
+
+        - name: Copy docker-compose.yml to NCP server
+          uses: appleboy/scp-action@master
+          with:
+            host: ${{ secrets.SERVER_HOST }}
+            username: ${{ secrets.SERVER_USER }}
+            key: ${{ secrets.SERVER_SSH_KEY }}
+            source: ./docker-compose.yml
+            target: /root
 
         # ---------------------- PROD Deployment ----------------------
         - name: Docker build & push (prod)

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,0 +1,126 @@
+name: CI/CD Workflow
+
+on:
+  push:
+    branches: [ "main", "develop", "chore/#4-cicd" ]
+
+jobs:
+  CI-CD:
+    runs-on: ubuntu-latest
+
+    steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+
+        - name: Set up JDK 21
+          uses: actions/setup-java@v4
+          with:
+            java-version: '21'
+            distribution: 'corretto'
+
+        - name: Gradle Caching
+          uses: actions/cache@v4
+          with:
+            path: |
+              ~/.gradle/caches
+              ~/.gradle/wrapper
+            key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+            restore-keys: |
+              ${{ runner.os }}-gradle-
+
+        - name: Grant execute permission for gradlew
+          run: chmod +x gradlew
+
+        - name: Build with Gradle
+          run: ./gradlew clean build -x test
+
+        - name: Create secrets files from GitHub Secrets
+          run: |
+            mkdir -p ./src/main/resources/secret
+            echo "${{ secrets.PROD_ENV_CONTENT }}" > ./src/main/resources/secret/prod.env
+            echo "${{ secrets.DEV_ENV_CONTENT }}" > ./src/main/resources/secret/dev.env
+            echo "${{ secrets.DEPLOY_FILE }}" > ./src/main/resources/secret/deploy.sh
+            chmod 600 ./src/main/resources/secret/*.env
+            chmod 600 ./src/main/resources/secret/deploy.sh
+            echo "✅ .env & .sh 파일 생성 완료"
+        
+
+        # 📌 개선: Docker Login을 별도 Step으로 분리하고 공식 액션 사용
+        - name: Docker Login
+          uses: docker/login-action@v3
+          with:
+            username: ${{ secrets.DOCKERHUB_USERNAME }}
+            password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+        # 📌 개선: prod.env, dev.env, deploy.sh 파일을 하나의 scp-action으로 통합 전송
+        - name: Copy deployment files to NCP server (Integrated SCP)
+          uses: appleboy/scp-action@master
+          with:
+            host: ${{ secrets.SERVER_HOST }}
+            username: ${{ secrets.SERVER_USER }}
+            key: ${{ secrets.SERVER_SSH_KEY }}
+            source: |
+              ./src/main/resources/secret/prod.env
+              ./src/main/resources/secret/dev.env
+              ./src/main/resources/secret/deploy.sh
+              ./docker-compose.yml
+            target: /root
+
+        # ---------------------- PROD Deployment ----------------------
+        - name: Docker build & push (prod)
+          if: github.ref == 'refs/heads/main'
+          run: |
+            SHA=${{ github.sha }}
+            SHORT_SHA=${SHA:0:7}
+            IMAGE_NAME=${{ secrets.DOCKER_REPO }}/${{ secrets.DOCKER_IMAGE_NAME }}
+            
+            echo "✅ Building $IMAGE_NAME with tags $SHORT_SHA and prod"
+            
+            docker build -f Dockerfile -t $IMAGE_NAME:$SHORT_SHA .
+            docker tag $IMAGE_NAME:$SHORT_SHA $IMAGE_NAME:prod
+            
+            docker push $IMAGE_NAME:$SHORT_SHA
+            docker push $IMAGE_NAME:prod
+            
+            echo "✅ Pushed $IMAGE_NAME:$SHORT_SHA and $IMAGE_NAME:prod"
+
+        - name: Deploy to prod
+          if: github.ref == 'refs/heads/main'
+          uses: appleboy/ssh-action@master
+          with:
+            host: ${{ secrets.SERVER_HOST }}
+            username: ${{ secrets.SERVER_USER }}
+            key: ${{ secrets.SERVER_SSH_KEY }}
+            script: |
+              echo "🚀 Deploying to PROD server..."
+              
+              cd /root
+              chmod +x deploy.sh
+              ./deploy.sh prod
+
+        # ---------------------- DEV Deployment ----------------------
+        - name: Docker build & push (develop)
+          if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/chore/#4-cicd'
+          run: |
+            IMAGE_NAME=${{ secrets.DOCKER_REPO }}/${{ secrets.DOCKER_IMAGE_NAME }}
+            
+            echo "✅ Building $IMAGE_NAME with tags dev"
+            
+            docker build -f Dockerfile -t $IMAGE_NAME:dev .
+            docker push $IMAGE_NAME:dev
+            
+            echo "✅ Pushed $IMAGE_NAME:dev"
+
+        - name: Deploy to develop
+          if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/chore/#4-cicd'
+          uses: appleboy/ssh-action@master
+          with:
+            host: ${{ secrets.SERVER_HOST }}
+            username: ${{ secrets.SERVER_USER }}
+            key: ${{ secrets.SERVER_SSH_KEY }}
+            script: |
+              echo "🚀 Deploying to DEV server..."
+              
+              cd /root
+              chmod +x deploy.sh
+              ./deploy.sh dev

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -2,7 +2,7 @@ name: CI/CD Workflow
 
 on:
   push:
-    branches: [ "main", "develop", "chore/#4-cicd" ]
+    branches: [ "main", "develop"]
 
 jobs:
   CI-CD:
@@ -126,7 +126,7 @@ jobs:
 
         # ---------------------- DEV Deployment ----------------------
         - name: Docker build & push (develop)
-          if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/chore/#4-cicd'
+          if: github.ref == 'refs/heads/develop'
           run: |
             IMAGE_NAME=${{ secrets.DOCKER_REPO }}/${{ secrets.DOCKER_IMAGE_NAME }}
             
@@ -138,7 +138,7 @@ jobs:
             echo "✅ Pushed $IMAGE_NAME:dev"
 
         - name: Deploy to develop
-          if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/chore/#4-cicd'
+          if: github.ref == 'refs/heads/develop'
           uses: appleboy/ssh-action@master
           with:
             host: ${{ secrets.SERVER_HOST }}

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -2,7 +2,7 @@ name: CI/CD Workflow
 
 on:
   push:
-    branches: [ "main", "develop", "chore/#4-cicd"]
+    branches: [ "main", "develop"]
 
 jobs:
   CI-CD:
@@ -126,7 +126,7 @@ jobs:
 
         # ---------------------- DEV Deployment ----------------------
         - name: Docker build & push (develop)
-          if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/chore/#4-cicd'
+          if: github.ref == 'refs/heads/develop'
           run: |
             IMAGE_NAME=${{ secrets.DOCKER_REPO }}/${{ secrets.DOCKER_IMAGE_NAME }}
             
@@ -138,7 +138,7 @@ jobs:
             echo "✅ Pushed $IMAGE_NAME:dev"
 
         - name: Deploy to develop
-          if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/chore/#4-cicd'
+          if: github.ref == 'refs/heads/develop'
           uses: appleboy/ssh-action@master
           with:
             host: ${{ secrets.SERVER_HOST }}

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -39,20 +39,20 @@ jobs:
             mkdir -p ./src/main/resources/secret
             echo "${{ secrets.PROD_ENV_CONTENT }}" > ./src/main/resources/secret/prod.env
             echo "${{ secrets.DEV_ENV_CONTENT }}" > ./src/main/resources/secret/dev.env
-            echo "${{ secrets.DEPLOY_FILE }}" > ./src/main/resources/secret/deploy.sh
+            cat <<'EOF' > ./src/main/resources/secret/deploy.sh
+            ${{ secrets.DEPLOY_FILE }}
+            EOF
             chmod 600 ./src/main/resources/secret/*.env
             chmod 600 ./src/main/resources/secret/deploy.sh
             echo "✅ .env & .sh 파일 생성 완료"
         
 
-        # 📌 개선: Docker Login을 별도 Step으로 분리하고 공식 액션 사용
         - name: Docker Login
           uses: docker/login-action@v3
           with:
             username: ${{ secrets.DOCKERHUB_USERNAME }}
             password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-        # 📌 개선: prod.env, dev.env, deploy.sh 파일을 하나의 scp-action으로 통합 전송
         - name: Copy deployment files to NCP server (Integrated SCP)
           uses: appleboy/scp-action@master
           with:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -61,7 +61,7 @@ jobs:
             key: ${{ secrets.SERVER_SSH_KEY }}
             source: ./src/main/resources/secret/prod.env
             target: /root
-            strip_components: 4
+            strip_components: 5
 
         - name: Copy dev.env to NCP server
           uses: appleboy/scp-action@master
@@ -71,7 +71,7 @@ jobs:
             key: ${{ secrets.SERVER_SSH_KEY }}
             source: ./src/main/resources/secret/dev.env
             target: /root
-            strip_components: 4
+            strip_components: 5
 
         - name: Copy deploy.sh to NCP server
           uses: appleboy/scp-action@master
@@ -81,7 +81,7 @@ jobs:
             key: ${{ secrets.SERVER_SSH_KEY }}
             source: ./src/main/resources/secret/deploy.sh
             target: /root
-            strip_components: 4
+            strip_components: 5
 
         - name: Copy docker-compose.yml to NCP server
           uses: appleboy/scp-action@master

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 
+src/main/resources/
+
 ### application.yml ###
 application.yml
 application-dev.yml

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 
-src/main/resources/
+src/main/resources/secret/
 
 ### application.yml ###
 application.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM amazoncorretto:21-alpine
+WORKDIR /app
+COPY ./build/libs/cheeeese-0.0.1-SNAPSHOT.jar /app/cheeeese.jar
+EXPOSE 8080
+ENTRYPOINT ["java"]
+CMD ["-jar", "cheeeese.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,11 @@ services:
     image: redis:7.2-alpine
     container_name: redis
     restart: always
+    command: [ "redis-server", "--requirepass", "${SPRING_DATA_REDIS_PASSWORD}" ]
     ports:
       - "6379:6379"
+    environment:
+      - REDIS_PASSWORD=${SPRING_DATA_REDIS_PASSWORD}
     volumes:
       - redis-data:/data
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,104 @@
+version: "3.9"
+
+services:
+  # ------------------------------------------------------------
+  # ✅ Redis 서비스 (항상 실행)
+  # ------------------------------------------------------------
+  redis:
+    image: redis:7.2-alpine
+    container_name: redis
+    restart: always
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis-data:/data
+    networks:
+      - cheeeeese-network
+
+  # ------------------------------------------------------------
+  # ✅ Backend 서비스 (Blue-Green 전환 대상)
+  # ------------------------------------------------------------
+  backend-green-prod:
+    image: mozzarella32/backend:prod     # deploy.sh에서 docker pull로 최신 이미지 갱신
+    container_name: cheeeeese-green-prod
+    env_file:
+      - /root/prod.env
+    depends_on:
+      - redis
+    ports:
+      - "8080:8080"     # Green 인스턴스 포트
+    restart: always
+    networks:
+      - cheeeeese-network
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  backend-blue-prod:
+    image: mozzarella32/backend:prod
+    container_name: cheeeeese-blue-prod
+    env_file:
+      - /root/prod.env
+    depends_on:
+      - redis
+    ports:
+      - "8081:8080"     # Blue 인스턴스 포트
+    restart: always
+    networks:
+      - cheeeeese-network
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  # ------------------------------------------------------------
+  # ✅ 개발 환경용
+  # ------------------------------------------------------------
+  backend-green-dev:
+    image: mozzarella32/backend:dev
+    container_name: cheeeeese-green-dev
+    env_file:
+      - /root/dev.env
+    depends_on:
+      - redis
+    ports:
+      - "8082:8080"
+    restart: always
+    networks:
+      - cheeeeese-network
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:8080/actuator/health" ]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  backend-blue-dev:
+    image: mozzarella32/backend:dev
+    container_name: cheeeeese-blue-dev
+    env_file:
+      - /root/dev.env
+    depends_on:
+      - redis
+    ports:
+      - "8083:8080"
+    restart: always
+    networks:
+      - cheeeeese-network
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:8080/actuator/health" ]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+# ------------------------------------------------------------
+# ✅ 네트워크 및 볼륨 정의
+# ------------------------------------------------------------
+networks:
+  cheeeeese-network:
+    driver: bridge
+
+volumes:
+  redis-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,8 @@ services:
     command: [ "redis-server", "--requirepass", "${SPRING_DATA_REDIS_PASSWORD}" ]
     ports:
       - "6379:6379"
-    environment:
-      - REDIS_PASSWORD=${SPRING_DATA_REDIS_PASSWORD}
+    env_file:
+      - /root/.env
     volumes:
       - redis-data:/data
     networks:
@@ -33,11 +33,6 @@ services:
     restart: always
     networks:
       - cheeeeese-network
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
-      interval: 5s
-      timeout: 3s
-      retries: 5
 
   backend-blue-prod:
     image: mozzarella32/backend:prod
@@ -51,11 +46,6 @@ services:
     restart: always
     networks:
       - cheeeeese-network
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
-      interval: 5s
-      timeout: 3s
-      retries: 5
 
   # ------------------------------------------------------------
   # ✅ 개발 환경용
@@ -72,11 +62,6 @@ services:
     restart: always
     networks:
       - cheeeeese-network
-    healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:8080/actuator/health" ]
-      interval: 5s
-      timeout: 3s
-      retries: 5
 
   backend-blue-dev:
     image: mozzarella32/backend:dev
@@ -90,11 +75,6 @@ services:
     restart: always
     networks:
       - cheeeeese-network
-    healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:8080/actuator/health" ]
-      interval: 5s
-      timeout: 3s
-      retries: 5
 
 # ------------------------------------------------------------
 # ✅ 네트워크 및 볼륨 정의


### PR DESCRIPTION
## 🔗 연관된 이슈
- #4 

## 🚀 변경 유형
- [ ] ✨ 기능 추가 (feature)
- [ ] 🐛 버그 수정 (fix)
- [ ] 📝 문서 변경 (docs)
- [ ] ♻️ 리팩토링 (refactor)
- [ ] 🧪 테스트 추가 / 수정 (test)
- [x] ⚙️ 설정 변경 (chore)

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- ncp 서버 띄우기
- cicd.yml 파일 작성
  - main/develop 브랜치 push 시 자동 빌드 및 배포
  - Secrets에서 .env, deploy.sh, docker-compose.yml 자동 생성 후 서버 전송
  - Docker Hub 로그인 및 이미지 빌드/푸시 자동화
  - NCP 서버에 SSH 접속 후 Blue-Green 배포 실행
- 서버 배포 스크립트 (deploy.sh)
  - Blue/Green 포트(8080~8083) 기반으로 무중단 배포
  - 현재 실행 컨테이너 감지 후 반대쪽 색상 컨테이너로 전환
  - Redis 자동 실행 및 컨테이너별 .env 파일 적용
  - 헬스체크 통과 후 Nginx upstream 자동 교체
- Nginx 설정 (/etc/nginx/sites-available/app.conf)
  - prod-upstream, dev-upstream 블록을 각각 구성
  - 프록시 요청을 자동으로 현재 포트에 연결
  - deploy.sh에서 sed 명령어로 포트 자동 교체

## 📸 스크린샷
>
<img width="524" height="301" alt="스크린샷 2025-10-15 오후 5 39 46" src="https://github.com/user-attachments/assets/7d2109fb-3041-4f57-8dd2-93bba954b212" />
<img width="739" height="92" alt="스크린샷 2025-10-15 오후 5 41 44" src="https://github.com/user-attachments/assets/9b320cb4-8751-4741-a8e1-c9472d54c95d" />


## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
- nginx 80 -> prod 8080 / 8081
- nginx 81 -> dev 8082 / 8083

- 현재 mysql은 서버 내에서 실행되고 있고, rds 세팅 완료하면 변경 예정입니다.
- 주요 파일 내용은 notion에 정리해놓겠습니다.

### 💙 도움주신 분 : @chyun7114 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 애플리케이션 실행용 Docker 이미지 제공
  - docker-compose로 Redis 연동 및 블루-그린 방식의 프로덕션/개발 서비스 구성 추가
- 버그 수정
  - 해당 없음
- 작업
  - 브랜치 기반 자동 빌드·배포 CI/CD 파이프라인 도입(메인/개발별 이미지 빌드·푸시 및 원격 배포 자동화)
  - 민감 정보 파일 관리 및 버전관리 제외 규칙 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->