### PR TITLE
feat: 사진 presignedUrl 발급 및 업로드 보고 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,11 @@ dependencies {
 
     // uuid v7
 	implementation 'com.github.f4b6a3:uuid-creator:5.2.0'
+
+	// AWS SDK for S3
+	implementation 'software.amazon.awssdk:s3:2.25.46'
+	implementation 'software.amazon.awssdk:auth:2.25.46'
+	implementation 'software.amazon.awssdk:regions:2.25.46'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/cheeeese/album/application/validator/AlbumValidator.java
+++ b/src/main/java/com/cheeeese/album/application/validator/AlbumValidator.java
@@ -68,6 +68,15 @@ public class AlbumValidator {
         validateUserBlacklisted(album, user);
     }
 
+    public void validateUploadPermission(Album album, User user) { // [NEW]
+        validateAlbumExpiration(album);
+
+        validateUserBlacklisted(album, user);
+
+        albumParticipantRepository.findByUserIdAndAlbumId(user.getId(), album.getId())
+                .orElseThrow(() -> new AlbumException(AlbumErrorCode.USER_NOT_PARTICIPANT));
+    }
+
     /**
      * 사용자가 앨범의 블랙리스트에 등록되어 있는지 확인합니다.
      */

--- a/src/main/java/com/cheeeese/album/exception/code/AlbumErrorCode.java
+++ b/src/main/java/com/cheeeese/album/exception/code/AlbumErrorCode.java
@@ -21,6 +21,7 @@ public enum AlbumErrorCode implements BaseCode {
     ALBUM_EVENT_DATE_INVALID(HttpStatus.BAD_REQUEST, "행사 날짜는 오늘 또는 과거만 선택 가능합니다."),
     ALBUM_INVALID_CAPACITY(HttpStatus.BAD_REQUEST, "앨범 인원은 최소 1명 이상 최대 64명 이하여야 합니다."),
     ALBUM_CREATION_LIMIT_EXCEEDED(HttpStatus.CONFLICT, "사용자는 일주일에 최대 3개의 앨범만 생성할 수 있습니다."),
+    USER_NOT_PARTICIPANT(HttpStatus.FORBIDDEN, "사용자는 해당 앨범의 참가자가 아닙니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/cheeeese/album/infrastructure/persistence/AlbumRepository.java
+++ b/src/main/java/com/cheeeese/album/infrastructure/persistence/AlbumRepository.java
@@ -28,4 +28,8 @@ public interface AlbumRepository extends JpaRepository<Album, Long> {
             @Param("start") LocalDateTime start,
             @Param("end") LocalDateTime end
     );
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE Album a SET a.currentPhotoCount = a.currentPhotoCount + :count WHERE a.id = :albumId")
+    int incrementPhotoCount(@Param("albumId") Long albumId, @Param("count") int count);
 }

--- a/src/main/java/com/cheeeese/album/infrastructure/persistence/AlbumRepository.java
+++ b/src/main/java/com/cheeeese/album/infrastructure/persistence/AlbumRepository.java
@@ -32,4 +32,8 @@ public interface AlbumRepository extends JpaRepository<Album, Long> {
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE Album a SET a.currentPhotoCount = a.currentPhotoCount + :count WHERE a.id = :albumId AND a.currentPhotoCount + :count <= a.maxPhotoCount")
     int incrementPhotoCount(@Param("albumId") Long albumId, @Param("count") int count);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE Album a SET a.currentPhotoCount = a.currentPhotoCount - :count WHERE a.id = :albumId AND a.currentPhotoCount >= :count")
+    int decrementPhotoCount(@Param("albumId") Long albumId, @Param("count") int count);
 }

--- a/src/main/java/com/cheeeese/album/infrastructure/persistence/AlbumRepository.java
+++ b/src/main/java/com/cheeeese/album/infrastructure/persistence/AlbumRepository.java
@@ -30,6 +30,6 @@ public interface AlbumRepository extends JpaRepository<Album, Long> {
     );
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
-    @Query("UPDATE Album a SET a.currentPhotoCount = a.currentPhotoCount + :count WHERE a.id = :albumId")
+    @Query("UPDATE Album a SET a.currentPhotoCount = a.currentPhotoCount + :count WHERE a.id = :albumId AND a.currentPhotoCount + :count <= a.maxPhotoCount")
     int incrementPhotoCount(@Param("albumId") Long albumId, @Param("count") int count);
 }

--- a/src/main/java/com/cheeeese/global/common/code/SuccessCode.java
+++ b/src/main/java/com/cheeeese/global/common/code/SuccessCode.java
@@ -24,6 +24,10 @@ public enum SuccessCode implements BaseCode {
     ALBUM_INVITATION_FETCH_SUCCESS(HttpStatus.OK, "앨범 초대장 정보 조회가 성공적으로 완료되었습니다."),
     ALBUM_ENTER_SUCCESS(HttpStatus.OK, "앨범 입장이 성공적으로 완료되었습니다."),
     ALBUM_CREATE_SUCCESS(HttpStatus.OK, "Album Create Success"),
+
+
+    // photo
+    PRESIGNED_URL_ISSUE_SUCCESS(HttpStatus.OK, "Presigned URL 발급이 성공적으로 완료되었습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/cheeeese/global/common/code/SuccessCode.java
+++ b/src/main/java/com/cheeeese/global/common/code/SuccessCode.java
@@ -28,6 +28,7 @@ public enum SuccessCode implements BaseCode {
 
     // photo
     PRESIGNED_URL_ISSUE_SUCCESS(HttpStatus.OK, "Presigned URL 발급이 성공적으로 완료되었습니다."),
+    PHOTO_UPLOAD_REPORT_SUCCESS(HttpStatus.OK, "사진 업로드 결과 보고가 성공적으로 처리되었습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/cheeeese/global/config/S3Config.java
+++ b/src/main/java/com/cheeeese/global/config/S3Config.java
@@ -1,0 +1,54 @@
+package com.cheeeese.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+import java.net.URI;
+
+@Configuration
+public class S3Config {
+
+    @Value("${ncp.object-storage.access-key}")
+    private String accessKey;
+
+    @Value("${ncp.object-storage.secret-key}")
+    private String secretKey;
+
+    @Value("${ncp.object-storage.endpoint}")
+    private String endpoint;
+
+    @Value("${ncp.object-storage.region}")
+    private String region;
+
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .region(Region.of(region))
+                .endpointOverride(URI.create(endpoint))
+                .credentialsProvider(
+                        StaticCredentialsProvider.create(
+                                AwsBasicCredentials.create(accessKey, secretKey)
+                        )
+                )
+                .build();
+    }
+
+    @Bean
+    public S3Presigner s3Presigner() {
+        return S3Presigner.builder()
+                .region(Region.of(region))
+                .endpointOverride(URI.create(endpoint))
+                .credentialsProvider(
+                        StaticCredentialsProvider.create(
+                                AwsBasicCredentials.create(accessKey, secretKey)
+                        )
+                )
+                .build();
+    }
+}

--- a/src/main/java/com/cheeeese/photo/application/PhotoService.java
+++ b/src/main/java/com/cheeeese/photo/application/PhotoService.java
@@ -9,9 +9,12 @@ import com.cheeeese.photo.domain.PhotoStatus;
 import com.cheeeese.photo.dto.request.PhotoPresignedUrlRequest;
 import com.cheeeese.photo.dto.request.PhotoUploadReportRequest;
 import com.cheeeese.photo.dto.response.PhotoPresignedUrlResponse;
+import com.cheeeese.photo.exception.PhotoException;
+import com.cheeeese.photo.exception.code.PhotoErrorCode;
 import com.cheeeese.photo.infrastructure.mapper.PhotoMapper;
 import com.cheeeese.photo.infrastructure.persistence.PhotoRepository;
 import com.cheeeese.user.domain.User;
+import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,7 +34,7 @@ public class PhotoService {
     private final AlbumRepository albumRepository;
     private final PresignedUrlService presignedUrlService;
 
-    private static final String ORIGINAL_PHOTO_PATH_FORMAT = "album/%d/original/%d_%s";
+    private static final String ORIGINAL_PHOTO_PATH_FORMAT = "album/%s/original/%d_%s";
 
     public long countTotalPhotos(Long albumId) {
         return photoRepository.countByAlbumIdAndIsDeletedFalse(albumId);
@@ -49,9 +52,12 @@ public class PhotoService {
         Album album = validateAlbumAndPermission(user, request.albumCode());
         validateUploadRequest(album, request);
 
-        List<PhotoPresignedUrlResponse.PresignedUrlInfo> presignedUrls = generatePresignedUrls(user, album, request.fileInfos());
-        albumRepository.incrementPhotoCount(album.getId(), request.fileInfos().size());
+        int updatedRows = albumRepository.incrementPhotoCount(album.getId(), request.fileInfos().size());
+        if (updatedRows != 1) {
+            throw new PhotoException(PhotoErrorCode.PHOTO_COUNT_INCREMENT_FAILED);
+        }
 
+        List<PhotoPresignedUrlResponse.PresignedUrlInfo> presignedUrls = generatePresignedUrls(user, album, request.fileInfos());
         return PhotoMapper.toPresignedUrlResponse(presignedUrls);
     }
 
@@ -98,11 +104,12 @@ public class PhotoService {
         Photo photo = PhotoMapper.toEntity(user.getId(), album.getId());
         photoRepository.save(photo);
 
+        String safeFileName = sanitizeFileName(file.fileName());
         String objectKey = String.format(
                 ORIGINAL_PHOTO_PATH_FORMAT,
-                album.getId(),
+                album.getCode(),
                 photo.getId(),
-                file.fileName()
+                safeFileName
         );
 
         String uploadUrl = presignedUrlService.generatePresignedPutUrl(objectKey, file.contentType());
@@ -111,7 +118,25 @@ public class PhotoService {
         return PhotoMapper.toPresignedUrlInfo(photo.getId(), uploadUrl);
     }
 
+    private String sanitizeFileName(String raw) {
+        String name = raw == null ? "unnamed" : raw;
+        name = name.replace('\\', '/'); // 구분자 통일
+        int idx = name.lastIndexOf('/');
+        if (idx >= 0) name = name.substring(idx + 1); // 경로 제거
+        name = name.replaceAll("[^a-zA-Z0-9._-]", "_"); // 허용 문자 화이트리스트
+        if (name.isBlank()) name = "unnamed";
+        return name;
+    }
+
     private PhotoValidator.ValidatedPhotos validateRequestAndPhotos(User user, PhotoUploadReportRequest request) {
+        var success = new java.util.HashSet<>(request.successPhotoIds());
+        var failure = new java.util.HashSet<>(request.failurePhotoIds());
+        success.retainAll(failure);
+
+        if (!success.isEmpty()) {
+            throw new PhotoException(PhotoErrorCode.PHOTO_REPORT_CONFLICTING_IDS);
+        }
+
         List<Long> allPhotoIds = Stream.concat(
                 request.successPhotoIds().stream(),
                 request.failurePhotoIds().stream()
@@ -125,12 +150,16 @@ public class PhotoService {
             return;
         }
 
-        photoRepository.updateStatusByIdsAndUserIdAndExpectedStatus(
+        int updatedRows = photoRepository.updateStatusByIdsAndUserIdAndExpectedStatus(
                 successPhotoIds,
                 userId,
                 PhotoStatus.PROCESSING,
                 PhotoStatus.UPLOADING
         );
+
+        if (updatedRows != successPhotoIds.size()) {
+            throw new PhotoException(PhotoErrorCode.PHOTO_STATUS_UPDATE_FAILED);
+        }
     }
 
     private void handleFailedUploads(Long userId, Long albumId, List<Long> failurePhotoIds) {
@@ -138,14 +167,21 @@ public class PhotoService {
             return;
         }
 
-        photoRepository.updateStatusByIdsAndUserIdAndExpectedStatus(
+        int updatedRows = photoRepository.updateStatusByIdsAndUserIdAndExpectedStatus(
                 failurePhotoIds,
                 userId,
                 PhotoStatus.FAILED,
                 PhotoStatus.UPLOADING
         );
 
-        albumRepository.decrementPhotoCount(albumId, failurePhotoIds.size());
+        if (updatedRows != failurePhotoIds.size()) {
+            throw new PhotoException(PhotoErrorCode.PHOTO_STATUS_UPDATE_FAILED);
+        }
+
+        int decremented = albumRepository.decrementPhotoCount(albumId, failurePhotoIds.size());
+        if (decremented == 0) {
+            throw new PhotoException(PhotoErrorCode.PHOTO_COUNT_DECREMENT_FAILED);
+        }
     }
 
 

--- a/src/main/java/com/cheeeese/photo/application/PhotoService.java
+++ b/src/main/java/com/cheeeese/photo/application/PhotoService.java
@@ -31,6 +31,8 @@ public class PhotoService {
     private final AlbumRepository albumRepository;
     private final PresignedUrlService presignedUrlService;
 
+    private static final String ORIGINAL_PHOTO_PATH_FORMAT = "album/%d/original/%d_%s";
+
     public long countTotalPhotos(Long albumId) {
         return photoRepository.countByAlbumIdAndIsDeletedFalse(albumId);
     }
@@ -43,81 +45,108 @@ public class PhotoService {
     }
 
     @Transactional
-    public PhotoPresignedUrlResponse createPresignedUrls(
-            User user,
-            PhotoPresignedUrlRequest request
-    ) {
-        Album album = albumValidator.validateAlbumCode(request.albumCode());
-        albumValidator.validateUploadPermission(album, user);
+    public PhotoPresignedUrlResponse createPresignedUrls(User user, PhotoPresignedUrlRequest request) {
+        Album album = validateAlbumAndPermission(user, request.albumCode());
+        validateUploadRequest(album, request);
 
-        int currentCount = album.getCurrentPhotoCount();
-        int maxCount = album.getMaxPhotoCount();
-        int requestedCount = request.fileInfos().size();
-
-        photoValidator.validatePhotoCount(currentCount, requestedCount, maxCount);
-        photoValidator.validateFileInfos(request.fileInfos());
-
-        List<PhotoPresignedUrlResponse.PresignedUrlInfo> presignedUrls =
-                request.fileInfos().stream()
-                        .map(file -> {
-                            Photo photo = PhotoMapper.toEntity(
-                                    user.getId(),
-                                    album.getId()
-                            );
-                            photoRepository.save(photo);
-
-                            String objectKey = String.format(
-                                    "album/%d/original/%d_%s",
-                                    album.getId(),
-                                    photo.getId(),
-                                    file.fileName()
-                            );
-
-                            String uploadUrl = presignedUrlService.generatePresignedPutUrl(
-                                    objectKey,
-                                    file.contentType()
-                            );
-
-                            photo.updateImageUrl(objectKey);
-
-                            return PhotoMapper.toPresignedUrlInfo(photo.getId(), uploadUrl);
-                        })
-                        .collect(Collectors.toList());
-
-        albumRepository.incrementPhotoCount(album.getId(), requestedCount);
+        List<PhotoPresignedUrlResponse.PresignedUrlInfo> presignedUrls = generatePresignedUrls(user, album, request.fileInfos());
+        albumRepository.incrementPhotoCount(album.getId(), request.fileInfos().size());
 
         return PhotoMapper.toPresignedUrlResponse(presignedUrls);
     }
 
     @Transactional
     public void reportUploadResult(User user, PhotoUploadReportRequest request) {
+        PhotoValidator.ValidatedPhotos validated = validateRequestAndPhotos(user, request);
+        Long albumId = validated.albumId();
+
+        handleSuccessfulUploads(user.getId(), request.successPhotoIds());
+
+        handleFailedUploads(user.getId(), albumId, request.failurePhotoIds());
+    }
+
+    private Album validateAlbumAndPermission(User user, String albumCode) {
+        Album album = albumValidator.validateAlbumCode(albumCode);
+        albumValidator.validateUploadPermission(album, user);
+        return album;
+    }
+
+    private void validateUploadRequest(Album album, PhotoPresignedUrlRequest request) {
+        int currentCount = album.getCurrentPhotoCount();
+        int maxCount = album.getMaxPhotoCount();
+        int requestedCount = request.fileInfos().size();
+
+        photoValidator.validatePhotoCount(currentCount, requestedCount, maxCount);
+        photoValidator.validateFileInfos(request.fileInfos());
+    }
+
+    private List<PhotoPresignedUrlResponse.PresignedUrlInfo> generatePresignedUrls(
+            User user,
+            Album album,
+            List<PhotoPresignedUrlRequest.FileInfo> fileInfos
+    ) {
+        return fileInfos.stream()
+                .map(file -> createPresignedUrlForFile(user, album, file))
+                .collect(Collectors.toList());
+    }
+
+    private PhotoPresignedUrlResponse.PresignedUrlInfo createPresignedUrlForFile(
+            User user,
+            Album album,
+            PhotoPresignedUrlRequest.FileInfo file
+    ) {
+        Photo photo = PhotoMapper.toEntity(user.getId(), album.getId());
+        photoRepository.save(photo);
+
+        String objectKey = String.format(
+                ORIGINAL_PHOTO_PATH_FORMAT,
+                album.getId(),
+                photo.getId(),
+                file.fileName()
+        );
+
+        String uploadUrl = presignedUrlService.generatePresignedPutUrl(objectKey, file.contentType());
+        photo.updateImageUrl(objectKey);
+
+        return PhotoMapper.toPresignedUrlInfo(photo.getId(), uploadUrl);
+    }
+
+    private PhotoValidator.ValidatedPhotos validateRequestAndPhotos(User user, PhotoUploadReportRequest request) {
         List<Long> allPhotoIds = Stream.concat(
                 request.successPhotoIds().stream(),
                 request.failurePhotoIds().stream()
         ).toList();
 
-        PhotoValidator.ValidatedPhotos validated = photoValidator.validatePhotos(user.getId(), allPhotoIds);
-        Long albumId = validated.albumId();
-
-
-        if (!request.successPhotoIds().isEmpty()) {
-            photoRepository.updateStatusByIdsAndUserIdAndExpectedStatus(
-                    request.successPhotoIds(),
-                    user.getId(),
-                    PhotoStatus.PROCESSING,
-                    PhotoStatus.UPLOADING
-            );
-        }
-
-        if (!request.failurePhotoIds().isEmpty()) {
-            photoRepository.updateStatusByIdsAndUserIdAndExpectedStatus(
-                    request.failurePhotoIds(),
-                    user.getId(),
-                    PhotoStatus.FAILED,
-                    PhotoStatus.UPLOADING
-            );
-            albumRepository.decrementPhotoCount(albumId, request.failurePhotoIds().size());
-        }
+        return photoValidator.validatePhotos(user.getId(), allPhotoIds);
     }
+
+    private void handleSuccessfulUploads(Long userId, List<Long> successPhotoIds) {
+        if (successPhotoIds == null || successPhotoIds.isEmpty()) {
+            return;
+        }
+
+        photoRepository.updateStatusByIdsAndUserIdAndExpectedStatus(
+                successPhotoIds,
+                userId,
+                PhotoStatus.PROCESSING,
+                PhotoStatus.UPLOADING
+        );
+    }
+
+    private void handleFailedUploads(Long userId, Long albumId, List<Long> failurePhotoIds) {
+        if (failurePhotoIds == null || failurePhotoIds.isEmpty()) {
+            return;
+        }
+
+        photoRepository.updateStatusByIdsAndUserIdAndExpectedStatus(
+                failurePhotoIds,
+                userId,
+                PhotoStatus.FAILED,
+                PhotoStatus.UPLOADING
+        );
+
+        albumRepository.decrementPhotoCount(albumId, failurePhotoIds.size());
+    }
+
 
 }

--- a/src/main/java/com/cheeeese/photo/application/PhotoService.java
+++ b/src/main/java/com/cheeeese/photo/application/PhotoService.java
@@ -45,7 +45,7 @@ public class PhotoService {
             PhotoPresignedUrlRequest request
     ) {
         Album album = albumValidator.validateAlbumCode(request.albumCode());
-        albumValidator.validateAlbumExpiration(album);
+        albumValidator.validateUploadPermission(album, user);
 
         int currentCount = album.getCurrentPhotoCount();
         int maxCount = album.getMaxPhotoCount();

--- a/src/main/java/com/cheeeese/photo/application/PhotoService.java
+++ b/src/main/java/com/cheeeese/photo/application/PhotoService.java
@@ -1,7 +1,15 @@
 package com.cheeeese.photo.application;
 
+import com.cheeeese.album.application.validator.AlbumValidator;
+import com.cheeeese.album.domain.Album;
+import com.cheeeese.album.infrastructure.persistence.AlbumRepository;
+import com.cheeeese.photo.application.validator.PhotoValidator;
 import com.cheeeese.photo.domain.Photo;
+import com.cheeeese.photo.dto.request.PhotoPresignedUrlRequest;
+import com.cheeeese.photo.dto.response.PhotoPresignedUrlResponse;
+import com.cheeeese.photo.infrastructure.mapper.PhotoMapper;
 import com.cheeeese.photo.infrastructure.persistence.PhotoRepository;
+import com.cheeeese.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,6 +23,10 @@ import java.util.stream.Collectors;
 public class PhotoService {
 
     private final PhotoRepository photoRepository;
+    private final PhotoValidator photoValidator;
+    private final AlbumValidator albumValidator;
+    private final AlbumRepository albumRepository;
+    private final PresignedUrlService presignedUrlService;
 
     public long countTotalPhotos(Long albumId) {
         return photoRepository.countByAlbumIdAndIsDeletedFalse(albumId);
@@ -26,4 +38,52 @@ public class PhotoService {
                 .map(Photo::getImageUrl)
                 .collect(Collectors.toList());
     }
+
+    @Transactional
+    public PhotoPresignedUrlResponse createPresignedUrls(
+            User user,
+            PhotoPresignedUrlRequest request
+    ) {
+        Album album = albumValidator.validateAlbumCode(request.albumCode());
+        albumValidator.validateAlbumExpiration(album);
+
+        int currentCount = album.getCurrentPhotoCount();
+        int maxCount = album.getMaxPhotoCount();
+        int requestedCount = request.fileInfos().size();
+
+        photoValidator.validatePhotoCount(currentCount, requestedCount, maxCount);
+        photoValidator.validateFileInfos(request.fileInfos());
+
+        List<PhotoPresignedUrlResponse.PresignedUrlInfo> presignedUrls =
+                request.fileInfos().stream()
+                        .map(file -> {
+                            Photo photo = PhotoMapper.toEntity(
+                                    user.getId(),
+                                    album.getId()
+                            );
+                            photoRepository.save(photo);
+
+                            String objectKey = String.format(
+                                    "album/%d/original/%d_%s",
+                                    album.getId(),
+                                    photo.getId(),
+                                    file.fileName()
+                            );
+
+                            String uploadUrl = presignedUrlService.generatePresignedPutUrl(
+                                    objectKey,
+                                    file.contentType()
+                            );
+
+                            photo.updateImageUrl(objectKey);
+
+                            return PhotoMapper.toPresignedUrlInfo(photo.getId(), uploadUrl);
+                        })
+                        .collect(Collectors.toList());
+
+        albumRepository.incrementPhotoCount(album.getId(), requestedCount);
+
+        return PhotoMapper.toPresignedUrlResponse(presignedUrls);
+    }
+
 }

--- a/src/main/java/com/cheeeese/photo/application/PhotoService.java
+++ b/src/main/java/com/cheeeese/photo/application/PhotoService.java
@@ -177,9 +177,11 @@ public class PhotoService {
             throw new PhotoException(PhotoErrorCode.PHOTO_STATUS_UPDATE_FAILED);
         }
 
-        int decremented = albumRepository.decrementPhotoCount(albumId, failurePhotoIds.size());
-        if (decremented == 0) {
-            throw new PhotoException(PhotoErrorCode.PHOTO_COUNT_DECREMENT_FAILED);
+        if (updatedRows > 0) {
+            int decremented = albumRepository.decrementPhotoCount(albumId, updatedRows);
+            if (decremented == 0) {
+                throw new PhotoException(PhotoErrorCode.PHOTO_COUNT_DECREMENT_FAILED);
+            }
         }
     }
 

--- a/src/main/java/com/cheeeese/photo/application/PhotoService.java
+++ b/src/main/java/com/cheeeese/photo/application/PhotoService.java
@@ -14,7 +14,6 @@ import com.cheeeese.photo.exception.code.PhotoErrorCode;
 import com.cheeeese.photo.infrastructure.mapper.PhotoMapper;
 import com.cheeeese.photo.infrastructure.persistence.PhotoRepository;
 import com.cheeeese.user.domain.User;
-import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/com/cheeeese/photo/application/PhotoService.java
+++ b/src/main/java/com/cheeeese/photo/application/PhotoService.java
@@ -5,7 +5,9 @@ import com.cheeeese.album.domain.Album;
 import com.cheeeese.album.infrastructure.persistence.AlbumRepository;
 import com.cheeeese.photo.application.validator.PhotoValidator;
 import com.cheeeese.photo.domain.Photo;
+import com.cheeeese.photo.domain.PhotoStatus;
 import com.cheeeese.photo.dto.request.PhotoPresignedUrlRequest;
+import com.cheeeese.photo.dto.request.PhotoUploadReportRequest;
 import com.cheeeese.photo.dto.response.PhotoPresignedUrlResponse;
 import com.cheeeese.photo.infrastructure.mapper.PhotoMapper;
 import com.cheeeese.photo.infrastructure.persistence.PhotoRepository;
@@ -16,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Service
 @RequiredArgsConstructor
@@ -84,6 +87,37 @@ public class PhotoService {
         albumRepository.incrementPhotoCount(album.getId(), requestedCount);
 
         return PhotoMapper.toPresignedUrlResponse(presignedUrls);
+    }
+
+    @Transactional
+    public void reportUploadResult(User user, PhotoUploadReportRequest request) {
+        List<Long> allPhotoIds = Stream.concat(
+                request.successPhotoIds().stream(),
+                request.failurePhotoIds().stream()
+        ).toList();
+
+        PhotoValidator.ValidatedPhotos validated = photoValidator.validatePhotos(user.getId(), allPhotoIds);
+        Long albumId = validated.albumId();
+
+
+        if (!request.successPhotoIds().isEmpty()) {
+            photoRepository.updateStatusByIdsAndUserIdAndExpectedStatus(
+                    request.successPhotoIds(),
+                    user.getId(),
+                    PhotoStatus.PROCESSING,
+                    PhotoStatus.UPLOADING
+            );
+        }
+
+        if (!request.failurePhotoIds().isEmpty()) {
+            photoRepository.updateStatusByIdsAndUserIdAndExpectedStatus(
+                    request.failurePhotoIds(),
+                    user.getId(),
+                    PhotoStatus.FAILED,
+                    PhotoStatus.UPLOADING
+            );
+            albumRepository.decrementPhotoCount(albumId, request.failurePhotoIds().size());
+        }
     }
 
 }

--- a/src/main/java/com/cheeeese/photo/application/PresignedUrlService.java
+++ b/src/main/java/com/cheeeese/photo/application/PresignedUrlService.java
@@ -1,0 +1,36 @@
+package com.cheeeese.photo.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+
+import java.time.Duration;
+
+@Component
+@RequiredArgsConstructor
+public class PresignedUrlService {
+
+    private final S3Presigner s3Presigner;
+
+    @Value("${ncp.object-storage.bucket}")
+    private String bucket;
+
+    public String generatePresignedPutUrl(String uniqueKey, String contentType) {
+        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                .bucket(bucket)
+                .key(uniqueKey)
+                .contentType(contentType)
+                .build();
+
+        PresignedPutObjectRequest presignedRequest =
+                s3Presigner.presignPutObject(p -> p
+                        .signatureDuration(Duration.ofMinutes(10))
+                        .putObjectRequest(putObjectRequest)
+                );
+
+        return presignedRequest.url().toString();
+    }
+}

--- a/src/main/java/com/cheeeese/photo/application/validator/PhotoValidator.java
+++ b/src/main/java/com/cheeeese/photo/application/validator/PhotoValidator.java
@@ -1,0 +1,49 @@
+package com.cheeeese.photo.application.validator;
+
+import com.cheeeese.photo.dto.request.PhotoPresignedUrlRequest;
+import com.cheeeese.photo.exception.PhotoException;
+import com.cheeeese.photo.exception.code.PhotoErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class PhotoValidator {
+
+    private static final long MAX_FILE_SIZE = 6 * 1024 * 1024; // 6MB
+    private static final List<String> ALLOWED_TYPES = List.of("image/jpeg", "image/png", "image/jpg");
+
+    /**
+     * presigned URL 발급 전, 파일 정보 형식/용량 검증
+     */
+    public void validateFileInfos(List<PhotoPresignedUrlRequest.FileInfo> fileInfos) {
+        if (fileInfos == null || fileInfos.isEmpty()) {
+            throw new PhotoException(PhotoErrorCode.PHOTO_FILE_LIST_EMPTY);
+        }
+
+        for (PhotoPresignedUrlRequest.FileInfo file : fileInfos) {
+            if (file.fileName() == null || file.fileName().isBlank()) {
+                throw new PhotoException(PhotoErrorCode.PHOTO_FILE_NAME_REQUIRED);
+            }
+
+            if (file.fileSize() > MAX_FILE_SIZE) {
+                throw new PhotoException(PhotoErrorCode.PHOTO_FILE_SIZE_EXCEEDED);
+            }
+
+            if (!ALLOWED_TYPES.contains(file.contentType())) {
+                throw new PhotoException(PhotoErrorCode.PHOTO_INVALID_CONTENT_TYPE);
+            }
+        }
+    }
+
+    /**
+     * 앨범 내 업로드 제한 검증
+     */
+    public void validatePhotoCount(int currentCount, int uploadCount, int maxPhotoCount) {
+        if (currentCount + uploadCount > maxPhotoCount) {
+            throw new PhotoException(PhotoErrorCode.PHOTO_MAX_COUNT_EXCEEDED);
+        }
+    }
+}

--- a/src/main/java/com/cheeeese/photo/application/validator/PhotoValidator.java
+++ b/src/main/java/com/cheeeese/photo/application/validator/PhotoValidator.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -79,21 +80,21 @@ public class PhotoValidator {
      * photoId 리스트 기반으로 존재하는 사진 조회 및 존재 검증
      */
     private List<Photo> findAndValidateExistence(List<Long> photoIds) {
-        List<Photo> photos = photoRepository.findAllById(photoIds);
+        Set<Long> requestedIds = new HashSet<>(photoIds);
+        List<Photo> photos = photoRepository.findAllById(requestedIds);
 
-        if (photos.size() != photoIds.size()) {
-            Set<Long> foundIds = photos.stream()
-                    .map(Photo::getId)
-                    .collect(Collectors.toSet());
+        Set<Long> foundIds = photos.stream()
+                .map(Photo::getId)
+                .collect(Collectors.toSet());
 
-            List<Long> missingIds = photoIds.stream()
-                    .filter(id -> !foundIds.contains(id))
-                    .toList();
+        Set<Long> missingIds = requestedIds.stream()
+                .filter(id -> !foundIds.contains(id))
+                .collect(Collectors.toSet());
 
+        if (!missingIds.isEmpty()) {
             log.error("존재하지 않는 photoIds: {}", missingIds);
             throw new PhotoException(PhotoErrorCode.PHOTO_ID_NOT_FOUND);
         }
-
         return photos;
     }
 

--- a/src/main/java/com/cheeeese/photo/application/validator/PhotoValidator.java
+++ b/src/main/java/com/cheeeese/photo/application/validator/PhotoValidator.java
@@ -1,16 +1,24 @@
 package com.cheeeese.photo.application.validator;
 
+import com.cheeeese.photo.domain.Photo;
 import com.cheeeese.photo.dto.request.PhotoPresignedUrlRequest;
 import com.cheeeese.photo.exception.PhotoException;
 import com.cheeeese.photo.exception.code.PhotoErrorCode;
+import com.cheeeese.photo.infrastructure.persistence.PhotoRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class PhotoValidator {
+
+    private final PhotoRepository photoRepository;
 
     private static final long MAX_FILE_SIZE = 6 * 1024 * 1024; // 6MB
     private static final List<String> ALLOWED_TYPES = List.of("image/jpeg", "image/png", "image/jpg");
@@ -46,4 +54,78 @@ public class PhotoValidator {
             throw new PhotoException(PhotoErrorCode.PHOTO_MAX_COUNT_EXCEEDED);
         }
     }
+
+    /**
+     * 존재, 소유, 동일 앨범 검증을 통합 수행
+     */
+    public ValidatedPhotos validatePhotos(Long userId, List<Long> photoIds) {
+        validatePhotoIdsNotEmpty(photoIds);
+        List<Photo> photos = findAndValidateExistence(photoIds);
+        validateOwnership(photos, userId);
+        Long albumId = validateSingleAlbum(photos);
+        return new ValidatedPhotos(photos, albumId);
+    }
+
+    /**
+     * photoIds가 비어있지 않은지 검증
+     */
+    private void validatePhotoIdsNotEmpty(List<Long> photoIds) {
+        if (photoIds == null || photoIds.isEmpty()) {
+            throw new PhotoException(PhotoErrorCode.PHOTO_ID_LIST_EMPTY);
+        }
+    }
+
+    /**
+     * photoId 리스트 기반으로 존재하는 사진 조회 및 존재 검증
+     */
+    private List<Photo> findAndValidateExistence(List<Long> photoIds) {
+        List<Photo> photos = photoRepository.findAllById(photoIds);
+
+        if (photos.size() != photoIds.size()) {
+            Set<Long> foundIds = photos.stream()
+                    .map(Photo::getId)
+                    .collect(Collectors.toSet());
+
+            List<Long> missingIds = photoIds.stream()
+                    .filter(id -> !foundIds.contains(id))
+                    .toList();
+
+            log.error("존재하지 않는 photoIds: {}", missingIds);
+            throw new PhotoException(PhotoErrorCode.PHOTO_ID_NOT_FOUND);
+        }
+
+        return photos;
+    }
+
+    /**
+     * 소유자 일치 검증
+     */
+    private void validateOwnership(List<Photo> photos, Long userId) {
+        boolean invalidOwner = photos.stream()
+                .anyMatch(photo -> !photo.getUserId().equals(userId));
+
+        if (invalidOwner) {
+            throw new PhotoException(PhotoErrorCode.PHOTO_OWNER_MISMATCH);
+        }
+    }
+
+    /**
+     * 동일 앨범 검증
+     */
+    private Long validateSingleAlbum(List<Photo> photos) {
+        Set<Long> albumIds = photos.stream()
+                .map(Photo::getAlbumId)
+                .collect(Collectors.toSet());
+
+        if (albumIds.size() != 1) {
+            throw new PhotoException(PhotoErrorCode.PHOTO_REPORT_INVALID_ALBUM);
+        }
+
+        return albumIds.iterator().next();
+    }
+
+    /**
+     * 검증 결과 객체: 앨범 ID + 사진 리스트 보관
+     */
+    public record ValidatedPhotos(List<Photo> photos, Long albumId) {}
 }

--- a/src/main/java/com/cheeeese/photo/domain/Photo.java
+++ b/src/main/java/com/cheeeese/photo/domain/Photo.java
@@ -61,10 +61,6 @@ public class Photo extends BaseEntity {
         this.status = status;
     }
 
-    public void updateStatus(PhotoStatus newStatus) {
-        this.status = newStatus;
-    }
-
     public void updateImageUrl(String imageUrl) {
         this.imageUrl = imageUrl;
     }

--- a/src/main/java/com/cheeeese/photo/domain/Photo.java
+++ b/src/main/java/com/cheeeese/photo/domain/Photo.java
@@ -28,7 +28,7 @@ public class Photo extends BaseEntity {
     @Column(name = "album_id", nullable = false)
     private Long albumId;
 
-    @Column(name = "image_url", nullable = false, columnDefinition = "TEXT")
+    @Column(name = "image_url", nullable = true, columnDefinition = "TEXT")
     private String imageUrl;
 
     @Column(name = "likes_cnt", nullable = false)
@@ -40,12 +40,17 @@ public class Photo extends BaseEntity {
     @Column(name = "is_deleted", nullable = false)
     private boolean isDeleted;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private PhotoStatus status;
+
     @Builder
     private Photo(
             Long userId,
             Long albumId,
             String imageUrl,
-            LocalDateTime captureTime
+            LocalDateTime captureTime,
+            PhotoStatus status
     ) {
         this.userId = userId;
         this.albumId = albumId;
@@ -53,5 +58,14 @@ public class Photo extends BaseEntity {
         this.captureTime = captureTime;
         this.likesCnt = 0;
         this.isDeleted = false;
+        this.status = status;
+    }
+
+    public void updateStatus(PhotoStatus newStatus) {
+        this.status = newStatus;
+    }
+
+    public void updateImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
     }
 }

--- a/src/main/java/com/cheeeese/photo/domain/PhotoStatus.java
+++ b/src/main/java/com/cheeeese/photo/domain/PhotoStatus.java
@@ -1,0 +1,8 @@
+package com.cheeeese.photo.domain;
+
+public enum PhotoStatus {
+    UPLOADING,
+    PROCESSING,
+    COMPLETED,
+    FAILED
+}

--- a/src/main/java/com/cheeeese/photo/dto/request/PhotoPresignedUrlRequest.java
+++ b/src/main/java/com/cheeeese/photo/dto/request/PhotoPresignedUrlRequest.java
@@ -1,0 +1,35 @@
+package com.cheeeese.photo.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+@Schema(description = "Presigned URL 발급 요청")
+public record PhotoPresignedUrlRequest(
+        @NotNull
+        @Schema(description = "앨범 코드", example = "786ccd09-5f22-4aa9-a32b-f62dd2e94cc8")
+        String albumCode,
+
+        @NotNull
+        @Schema(description = "업로드할 파일 정보 목록")
+        List<FileInfo> fileInfos
+) {
+    @Builder
+    @Schema(description = "개별 파일 정보")
+    public record FileInfo(
+            @NotBlank
+            @Schema(description = "원본 파일명", example = "my_holiday_pic.jpg")
+            String fileName,
+
+            @Schema(description = "파일 크기 (Byte)", example = "3000000")
+            long fileSize,
+
+            @NotBlank
+            @Schema(description = "파일 Content-Type", example = "image/jpeg")
+            String contentType
+    ) {}
+}

--- a/src/main/java/com/cheeeese/photo/dto/request/PhotoUploadReportRequest.java
+++ b/src/main/java/com/cheeeese/photo/dto/request/PhotoUploadReportRequest.java
@@ -1,0 +1,20 @@
+package com.cheeeese.photo.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+@Schema(description = "사진 업로드 결과 보고 요청 (부분 성공/실패 처리)")
+public record PhotoUploadReportRequest(
+        @NotNull
+        @Schema(description = "업로드가 성공적으로 완료된 사진 ID 목록 (UPLOADING -> PROCESSING)", example = "[100, 102]")
+        List<Long> successPhotoIds,
+
+        @NotNull
+        @Schema(description = "업로드 중 실패하거나 취소된 사진 ID 목록 (UPLOADING -> FAILED & 롤백)", example = "[101, 103]")
+        List<Long> failurePhotoIds
+) {
+}

--- a/src/main/java/com/cheeeese/photo/dto/response/PhotoPresignedUrlResponse.java
+++ b/src/main/java/com/cheeeese/photo/dto/response/PhotoPresignedUrlResponse.java
@@ -1,0 +1,23 @@
+package com.cheeeese.photo.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+@Schema(description = "Presigned URL 발급 응답")
+public record PhotoPresignedUrlResponse(
+        @Schema(description = "발급된 Presigned URL 목록")
+        List<PresignedUrlInfo> presignedUrlInfos
+) {
+    @Builder
+    @Schema(description = "Presigned URL 정보")
+    public record PresignedUrlInfo(
+            @Schema(description = "저장된 사진 ID", example = "100")
+            Long photoId,
+
+            @Schema(description = "클라우드 스토리지에 업로드할 URL", example = "https://bucket.s3.ap-northeast-2.amazonaws.com/...")
+            String uploadUrl
+    ) {}
+}

--- a/src/main/java/com/cheeeese/photo/exception/PhotoException.java
+++ b/src/main/java/com/cheeeese/photo/exception/PhotoException.java
@@ -1,0 +1,13 @@
+package com.cheeeese.photo.exception;
+
+import com.cheeeese.global.exception.BusinessException;
+import com.cheeeese.photo.exception.code.PhotoErrorCode;
+import lombok.Getter;
+
+@Getter
+public class PhotoException extends BusinessException {
+    public PhotoException(PhotoErrorCode errorCode) {
+        super(errorCode);
+    }
+}
+

--- a/src/main/java/com/cheeeese/photo/exception/code/PhotoErrorCode.java
+++ b/src/main/java/com/cheeeese/photo/exception/code/PhotoErrorCode.java
@@ -14,7 +14,10 @@ public enum PhotoErrorCode implements BaseCode {
     PHOTO_INVALID_CONTENT_TYPE(HttpStatus.BAD_REQUEST, "유효한 이미지 파일 형식이 아닙니다."),
     PHOTO_FILE_LIST_EMPTY(HttpStatus.BAD_REQUEST, "업로드할 파일 목록이 비어 있습니다."),
     PHOTO_FILE_NAME_REQUIRED(HttpStatus.BAD_REQUEST, "파일명이 누락되었습니다."),
-    ;
+    PHOTO_ID_LIST_EMPTY(HttpStatus.BAD_REQUEST, "요청에 photoId 리스트가 비어 있습니다."),
+    PHOTO_REPORT_INVALID_ALBUM(HttpStatus.BAD_REQUEST, "보고된 사진들은 반드시 동일한 앨범에 속해야 합니다."),
+    PHOTO_OWNER_MISMATCH(HttpStatus.FORBIDDEN, "사용자와 사진의 소유자가 일치하지 않습니다."),
+    PHOTO_ID_NOT_FOUND(HttpStatus.NOT_FOUND, "보고된 사진 ID 중 존재하지 않는 ID가 포함되어 있습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/cheeeese/photo/exception/code/PhotoErrorCode.java
+++ b/src/main/java/com/cheeeese/photo/exception/code/PhotoErrorCode.java
@@ -9,8 +9,6 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum PhotoErrorCode implements BaseCode {
 
-    PHOTO_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않거나 유효하지 않은 사진 정보입니다."),
-
     PHOTO_MAX_COUNT_EXCEEDED(HttpStatus.BAD_REQUEST, "앨범의 최대 사진 개수를 초과합니다."),
     PHOTO_FILE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "파일 크기는 6MB를 초과할 수 없습니다."),
     PHOTO_INVALID_CONTENT_TYPE(HttpStatus.BAD_REQUEST, "유효한 이미지 파일 형식이 아닙니다."),

--- a/src/main/java/com/cheeeese/photo/exception/code/PhotoErrorCode.java
+++ b/src/main/java/com/cheeeese/photo/exception/code/PhotoErrorCode.java
@@ -9,15 +9,22 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum PhotoErrorCode implements BaseCode {
 
+    // Presigned URL 발급 관련 오류
     PHOTO_MAX_COUNT_EXCEEDED(HttpStatus.BAD_REQUEST, "앨범의 최대 사진 개수를 초과합니다."),
     PHOTO_FILE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "파일 크기는 6MB를 초과할 수 없습니다."),
     PHOTO_INVALID_CONTENT_TYPE(HttpStatus.BAD_REQUEST, "유효한 이미지 파일 형식이 아닙니다."),
     PHOTO_FILE_LIST_EMPTY(HttpStatus.BAD_REQUEST, "업로드할 파일 목록이 비어 있습니다."),
     PHOTO_FILE_NAME_REQUIRED(HttpStatus.BAD_REQUEST, "파일명이 누락되었습니다."),
+    PHOTO_COUNT_INCREMENT_FAILED(HttpStatus.CONFLICT, "앨범 사진 개수 증가에 실패했습니다."),
+
+    // 업로드 보고 관련 오류
     PHOTO_ID_LIST_EMPTY(HttpStatus.BAD_REQUEST, "요청에 photoId 리스트가 비어 있습니다."),
     PHOTO_REPORT_INVALID_ALBUM(HttpStatus.BAD_REQUEST, "보고된 사진들은 반드시 동일한 앨범에 속해야 합니다."),
     PHOTO_OWNER_MISMATCH(HttpStatus.FORBIDDEN, "사용자와 사진의 소유자가 일치하지 않습니다."),
     PHOTO_ID_NOT_FOUND(HttpStatus.NOT_FOUND, "보고된 사진 ID 중 존재하지 않는 ID가 포함되어 있습니다."),
+    PHOTO_REPORT_CONFLICTING_IDS(HttpStatus.BAD_REQUEST, "업로드 결과(success/failure) 목록에 중복된 사진 ID가 포함되어 있습니다."),
+    PHOTO_STATUS_UPDATE_FAILED(HttpStatus.CONFLICT, "사진 상태 업데이트에 실패했습니다."),
+    PHOTO_COUNT_DECREMENT_FAILED(HttpStatus.CONFLICT, "앨범 사진 개수 감소에 실패했습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/cheeeese/photo/exception/code/PhotoErrorCode.java
+++ b/src/main/java/com/cheeeese/photo/exception/code/PhotoErrorCode.java
@@ -1,0 +1,25 @@
+package com.cheeeese.photo.exception.code;
+
+import com.cheeeese.global.common.code.BaseCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum PhotoErrorCode implements BaseCode {
+
+    PHOTO_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않거나 유효하지 않은 사진 정보입니다."),
+
+    PHOTO_MAX_COUNT_EXCEEDED(HttpStatus.BAD_REQUEST, "앨범의 최대 사진 개수를 초과합니다."),
+    PHOTO_FILE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "파일 크기는 6MB를 초과할 수 없습니다."),
+    PHOTO_INVALID_CONTENT_TYPE(HttpStatus.BAD_REQUEST, "유효한 이미지 파일 형식이 아닙니다."),
+    PHOTO_FILE_LIST_EMPTY(HttpStatus.BAD_REQUEST, "업로드할 파일 목록이 비어 있습니다."),
+    PHOTO_FILE_NAME_REQUIRED(HttpStatus.BAD_REQUEST, "파일명이 누락되었습니다."),
+    ;
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}
+

--- a/src/main/java/com/cheeeese/photo/infrastructure/mapper/PhotoMapper.java
+++ b/src/main/java/com/cheeeese/photo/infrastructure/mapper/PhotoMapper.java
@@ -2,7 +2,6 @@ package com.cheeeese.photo.infrastructure.mapper;
 
 import com.cheeeese.photo.domain.Photo;
 import com.cheeeese.photo.domain.PhotoStatus;
-import com.cheeeese.photo.dto.request.PhotoPresignedUrlRequest;
 import com.cheeeese.photo.dto.response.PhotoPresignedUrlResponse;
 
 import java.time.LocalDateTime;

--- a/src/main/java/com/cheeeese/photo/infrastructure/mapper/PhotoMapper.java
+++ b/src/main/java/com/cheeeese/photo/infrastructure/mapper/PhotoMapper.java
@@ -1,0 +1,40 @@
+package com.cheeeese.photo.infrastructure.mapper;
+
+import com.cheeeese.photo.domain.Photo;
+import com.cheeeese.photo.domain.PhotoStatus;
+import com.cheeeese.photo.dto.request.PhotoPresignedUrlRequest;
+import com.cheeeese.photo.dto.response.PhotoPresignedUrlResponse;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class PhotoMapper {
+
+    public static Photo toEntity(Long userId, Long albumId) {
+        return Photo.builder()
+                .userId(userId)
+                .albumId(albumId)
+                .imageUrl(null) // presigned URL 생성 후 updateImageUrl()로 세팅됨
+                .captureTime(LocalDateTime.now())
+                .status(PhotoStatus.UPLOADING)
+                .build();
+    }
+
+    public static PhotoPresignedUrlResponse.PresignedUrlInfo toPresignedUrlInfo(
+            Long photoId,
+            String uploadUrl
+    ) {
+        return PhotoPresignedUrlResponse.PresignedUrlInfo.builder()
+                .photoId(photoId)
+                .uploadUrl(uploadUrl)
+                .build();
+    }
+
+    public static PhotoPresignedUrlResponse toPresignedUrlResponse(
+            List<PhotoPresignedUrlResponse.PresignedUrlInfo> presignedUrlInfos
+    ) {
+        return PhotoPresignedUrlResponse.builder()
+                .presignedUrlInfos(presignedUrlInfos)
+                .build();
+    }
+}

--- a/src/main/java/com/cheeeese/photo/infrastructure/persistence/PhotoRepository.java
+++ b/src/main/java/com/cheeeese/photo/infrastructure/persistence/PhotoRepository.java
@@ -1,7 +1,11 @@
 package com.cheeeese.photo.infrastructure.persistence;
 
 import com.cheeeese.photo.domain.Photo;
+import com.cheeeese.photo.domain.PhotoStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -10,4 +14,19 @@ public interface PhotoRepository extends JpaRepository<Photo, Long> {
     long countByAlbumIdAndIsDeletedFalse(Long albumId);
 
     List<Photo> findTop9ByAlbumIdAndIsDeletedFalseOrderByCreatedAtDesc(Long albumId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+        UPDATE Photo p
+        SET p.status = :newStatus
+        WHERE p.id IN :photoIds
+        AND p.userId = :userId
+        AND p.status = :expectedStatus
+    """)
+    int updateStatusByIdsAndUserIdAndExpectedStatus(
+            @Param("photoIds") List<Long> photoIds,
+            @Param("userId") Long userId,
+            @Param("newStatus") PhotoStatus newStatus,
+            @Param("expectedStatus") PhotoStatus expectedStatus
+    );
 }

--- a/src/main/java/com/cheeeese/photo/presentation/PhotoController.java
+++ b/src/main/java/com/cheeeese/photo/presentation/PhotoController.java
@@ -1,0 +1,32 @@
+package com.cheeeese.photo.presentation;
+
+import com.cheeeese.global.common.CommonResponse;
+import com.cheeeese.global.util.CurrentUser;
+import com.cheeeese.photo.application.PhotoService;
+import com.cheeeese.photo.dto.request.PhotoPresignedUrlRequest;
+import com.cheeeese.photo.dto.response.PhotoPresignedUrlResponse;
+import com.cheeeese.photo.presentation.swagger.PhotoSwagger;
+import com.cheeeese.user.domain.User;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import static com.cheeeese.global.common.code.SuccessCode.PRESIGNED_URL_ISSUE_SUCCESS;
+
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/photo")
+public class PhotoController implements PhotoSwagger {
+
+    private final PhotoService photoService;
+
+    @Override
+    @PostMapping("/presigned-url")
+    public CommonResponse<PhotoPresignedUrlResponse> createPresignedUrls(
+            @CurrentUser User user,
+            @RequestBody @Valid PhotoPresignedUrlRequest request
+    ) {
+        return CommonResponse.success(PRESIGNED_URL_ISSUE_SUCCESS, photoService.createPresignedUrls(user, request));
+    }
+}

--- a/src/main/java/com/cheeeese/photo/presentation/PhotoController.java
+++ b/src/main/java/com/cheeeese/photo/presentation/PhotoController.java
@@ -4,6 +4,7 @@ import com.cheeeese.global.common.CommonResponse;
 import com.cheeeese.global.util.CurrentUser;
 import com.cheeeese.photo.application.PhotoService;
 import com.cheeeese.photo.dto.request.PhotoPresignedUrlRequest;
+import com.cheeeese.photo.dto.request.PhotoUploadReportRequest;
 import com.cheeeese.photo.dto.response.PhotoPresignedUrlResponse;
 import com.cheeeese.photo.presentation.swagger.PhotoSwagger;
 import com.cheeeese.user.domain.User;
@@ -11,7 +12,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
-import static com.cheeeese.global.common.code.SuccessCode.PRESIGNED_URL_ISSUE_SUCCESS;
+import static com.cheeeese.global.common.code.SuccessCode.*;
 
 
 @RestController
@@ -28,5 +29,15 @@ public class PhotoController implements PhotoSwagger {
             @RequestBody @Valid PhotoPresignedUrlRequest request
     ) {
         return CommonResponse.success(PRESIGNED_URL_ISSUE_SUCCESS, photoService.createPresignedUrls(user, request));
+    }
+
+    @Override
+    @PostMapping("/report")
+    public CommonResponse<Void> reportUploadResult(
+            @CurrentUser User user,
+            @RequestBody @Valid PhotoUploadReportRequest request
+    ) {
+        photoService.reportUploadResult(user, request);
+        return CommonResponse.success(PHOTO_UPLOAD_REPORT_SUCCESS);
     }
 }

--- a/src/main/java/com/cheeeese/photo/presentation/swagger/PhotoSwagger.java
+++ b/src/main/java/com/cheeeese/photo/presentation/swagger/PhotoSwagger.java
@@ -107,6 +107,20 @@ public interface PhotoSwagger {
                     )
             ),
             @ApiResponse(
+                    responseCode = "400",
+                    description = "업로드 결과(success/failure) 목록에 중복된 사진 ID가 포함되어 있습니다.",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(example = """
+                        {
+                          "isSuccess": false,
+                          "code": 400,
+                          "message": "업로드 결과(success/failure) 목록에 중복된 사진 ID가 포함되어 있습니다."
+                        }
+                        """)
+                    )
+            ),
+            @ApiResponse(
                     responseCode = "403",
                     description = "사용자와 사진의 소유자가 일치하지 않습니다.",
                     content = @Content(
@@ -130,6 +144,20 @@ public interface PhotoSwagger {
                           "isSuccess": false,
                           "code": 404,
                           "message": "보고된 사진 ID 중 존재하지 않는 ID가 포함되어 있습니다."
+                        }
+                        """)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "409",
+                    description = "사진 상태 업데이트에 실패했습니다.",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(example = """
+                        {
+                          "isSuccess": false,
+                          "code": 409,
+                          "message": "사진 상태 업데이트에 실패했습니다."
                         }
                         """)
                     )

--- a/src/main/java/com/cheeeese/photo/presentation/swagger/PhotoSwagger.java
+++ b/src/main/java/com/cheeeese/photo/presentation/swagger/PhotoSwagger.java
@@ -52,6 +52,20 @@ public interface PhotoSwagger {
                                     }
                                     """)
                     )
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "사용자는 해당 앨범의 참가자가 아닙니다.",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(example = """
+                        {
+                          "isSuccess": false,
+                          "code": 403,
+                          "message": "사용자는 해당 앨범의 참가자가 아닙니다."
+                        }
+                        """)
+                    )
             )
     })
     CommonResponse<PhotoPresignedUrlResponse> createPresignedUrls(
@@ -77,6 +91,48 @@ public interface PhotoSwagger {
             @ApiResponse(
                     responseCode = "200",
                     description = "사진 업로드 결과 보고가 성공적으로 처리되었습니다."
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "보고된 사진들은 반드시 동일한 앨범에 속해야 합니다.",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(example = """
+                        {
+                          "isSuccess": false,
+                          "code": 400,
+                          "message": "보고된 사진들은 반드시 동일한 앨범에 속해야 합니다."
+                        }
+                        """)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "사용자와 사진의 소유자가 일치하지 않습니다.",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(example = """
+                        {
+                          "isSuccess": false,
+                          "code": 403,
+                          "message": "사용자와 사진의 소유자가 일치하지 않습니다."
+                        }
+                        """)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "보고된 사진 ID 중 존재하지 않는 ID가 포함되어 있습니다.",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(example = """
+                        {
+                          "isSuccess": false,
+                          "code": 404,
+                          "message": "보고된 사진 ID 중 존재하지 않는 ID가 포함되어 있습니다."
+                        }
+                        """)
+                    )
             )
     })
     CommonResponse<Void> reportUploadResult(

--- a/src/main/java/com/cheeeese/photo/presentation/swagger/PhotoSwagger.java
+++ b/src/main/java/com/cheeeese/photo/presentation/swagger/PhotoSwagger.java
@@ -3,6 +3,7 @@ package com.cheeeese.photo.presentation.swagger;
 import com.cheeeese.global.common.CommonResponse;
 import com.cheeeese.global.util.CurrentUser;
 import com.cheeeese.photo.dto.request.PhotoPresignedUrlRequest;
+import com.cheeeese.photo.dto.request.PhotoUploadReportRequest;
 import com.cheeeese.photo.dto.response.PhotoPresignedUrlResponse;
 import com.cheeeese.user.domain.User;
 import io.swagger.v3.oas.annotations.Operation;
@@ -56,5 +57,30 @@ public interface PhotoSwagger {
     CommonResponse<PhotoPresignedUrlResponse> createPresignedUrls(
             @CurrentUser User user,
             @RequestBody @Valid PhotoPresignedUrlRequest request
+    );
+
+    @Operation(
+            summary = "사진 업로드 결과 보고 API (부분 성공/실패 처리)", // [추가]
+            description = """ 
+                    ### RequestBody
+                    ---
+                    `successPhotoIds`: Object Storage 업로드 성공 ID 목록 \n
+                    `failurePhotoIds`: Object Storage 업로드 실패 ID 목록 \n
+                    
+                    ### 로직 상세
+                    ---
+                    1. **Success IDs 처리**: `Photo` 상태를 `UPLOADING`에서 `PROCESSING`으로 변경 (후처리 대기).
+                    2. **Failure IDs 처리**: `Photo` 상태를 `UPLOADING`에서 `FAILED`으로 변경, 앨범의 `currentPhotoCount`를 **롤백** (감소)합니다.
+                    """
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "사진 업로드 결과 보고가 성공적으로 처리되었습니다."
+            )
+    })
+    CommonResponse<Void> reportUploadResult(
+            @CurrentUser User user,
+            @RequestBody @Valid PhotoUploadReportRequest request
     );
 }

--- a/src/main/java/com/cheeeese/photo/presentation/swagger/PhotoSwagger.java
+++ b/src/main/java/com/cheeeese/photo/presentation/swagger/PhotoSwagger.java
@@ -29,7 +29,7 @@ public interface PhotoSwagger {
                     ---
                     1. 앨범의 존재 및 만료 여부 확인
                     2. 앨범의 최대 사진 개수 (`maxPhotoCount`) 초과 여부 확인
-                    3. 파일별 크기(6MB), Content-Type(image/*) 유효성 검증
+                    3. 파일별 크기(6MB), Content-Type(image/jpeg · image/png · image/jpg) 유효성 검증
                     4. 검증 통과 시, DB에 `Photo` 레코드를 `UPLOADING` 상태로 생성
                     5. 클라우드 스토리지 Presigned URL을 발급하여 반환
                     """

--- a/src/main/java/com/cheeeese/photo/presentation/swagger/PhotoSwagger.java
+++ b/src/main/java/com/cheeeese/photo/presentation/swagger/PhotoSwagger.java
@@ -1,0 +1,60 @@
+package com.cheeeese.photo.presentation.swagger;
+
+import com.cheeeese.global.common.CommonResponse;
+import com.cheeeese.global.util.CurrentUser;
+import com.cheeeese.photo.dto.request.PhotoPresignedUrlRequest;
+import com.cheeeese.photo.dto.response.PhotoPresignedUrlResponse;
+import com.cheeeese.user.domain.User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "[사진]", description = "사진 업로드 및 관리에 대한 API")
+public interface PhotoSwagger {
+    @Operation(
+            summary = "Presigned URL 발급 API",
+            description = """ 
+                    ### RequestBody
+                    ---
+                    `albumCode`: 사진을 업로드할 앨범의 코드 \n
+                    `fileInfos`: 업로드할 파일 정보 목록 (파일명, 크기, Content-Type) \n
+                    
+                    ### 로직 상세
+                    ---
+                    1. 앨범의 존재 및 만료 여부 확인
+                    2. 앨범의 최대 사진 개수 (`maxPhotoCount`) 초과 여부 확인
+                    3. 파일별 크기(6MB), Content-Type(image/*) 유효성 검증
+                    4. 검증 통과 시, DB에 `Photo` 레코드를 `UPLOADING` 상태로 생성
+                    5. 클라우드 스토리지 Presigned URL을 발급하여 반환
+                    """
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Presigned URL 발급이 성공적으로 완료되었습니다."
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "유효성 검증 실패 (최대 개수 초과, 파일 크기/형식 불일치 등)",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(example = """
+                                    {
+                                      "isSuccess": false,
+                                      "code": 400,
+                                      "message": "앨범의 최대 사진 개수를 초과합니다."
+                                    }
+                                    """)
+                    )
+            )
+    })
+    CommonResponse<PhotoPresignedUrlResponse> createPresignedUrls(
+            @CurrentUser User user,
+            @RequestBody @Valid PhotoPresignedUrlRequest request
+    );
+}


### PR DESCRIPTION
## 🔗 연관된 이슈
- #16 

## 🚀 변경 유형
- [x] ✨ 기능 추가 (feature)
- [ ] 🐛 버그 수정 (fix)
- [ ] 📝 문서 변경 (docs)
- [ ] ♻️ 리팩토링 (refactor)
- [ ] 🧪 테스트 추가 / 수정 (test)
- [ ] ⚙️ 설정 변경 (chore)

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- presigned-url 발급 로직 구현
  - 모두 다 성공을 예상하고 count 증가하는 로직으로 구현했습니다.
- 업로드 후 결과를 보고 받는 api 구현
  - 실패한 업로드에 대하여 count 롤백을 진행합니다.
  - 일단, FAILED로 상태 변경 후에 DB에서 삭제는 진행하지 않았습니다.(추후 변경 가능)

## 📸 스크린샷
>
- presigned-url 발급 성공  
  <img width="502" height="404" alt="스크린샷 2025-10-24 오후 5 26 28" src="https://github.com/user-attachments/assets/cee73527-8cce-4d28-bb0d-e163c9ec462e" />

- 최대 사진 개수 초과
  <img width="417" height="268" alt="스크린샷 2025-10-24 오후 1 42 38" src="https://github.com/user-attachments/assets/7f87b3cd-c3b5-41bf-a1b3-6e0b5c80436e" />

- 6MB 파일 크기 초과
  <img width="426" height="266" alt="스크린샷 2025-10-24 오후 1 43 14" src="https://github.com/user-attachments/assets/9d0c8e50-f865-4fa1-9f8c-6529d019bfc4" />

- 파일명 누락
  <img width="347" height="266" alt="스크린샷 2025-10-24 오후 1 44 21" src="https://github.com/user-attachments/assets/b3162519-2cfd-456d-bb65-26ac6c1702cf" />

- 이미지 형식 불일치
  <img width="397" height="262" alt="스크린샷 2025-10-24 오후 1 44 40" src="https://github.com/user-attachments/assets/bfb023ee-d343-4f93-888c-58a5ad7ed640" />

- 빈 업로드 파일 목록
  <img width="405" height="261" alt="스크린샷 2025-10-24 오후 1 46 11" src="https://github.com/user-attachments/assets/12028134-c3fd-4c4a-9021-9ce54823ac4f" />

- report 성공
  <img width="479" height="247" alt="스크린샷 2025-10-24 오후 5 30 16" src="https://github.com/user-attachments/assets/dc74839b-2e5e-484c-a154-2febd26e16cb" />

- 존재하지 않는 ID
  <img width="526" height="264" alt="스크린샷 2025-10-24 오후 4 50 39" src="https://github.com/user-attachments/assets/b0c1c51e-afbd-4e0a-afa7-639a3c441720" />

- 소유자 불일치
  <img width="451" height="265" alt="스크린샷 2025-10-24 오후 4 51 15" src="https://github.com/user-attachments/assets/4f4786f2-0eec-4fe7-9f3a-70e389d5639a" />

- 동일 앨범 아님
  <img width="488" height="265" alt="스크린샷 2025-10-24 오후 4 51 58" src="https://github.com/user-attachments/assets/6ca306ed-ec9a-45ff-9cec-58eed7ba5c01" />

## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
- FAILED 처리를 어떻게 해야할지 고민이 더 필요할 것 같습니다.
- s3 접근을 위한 yml 파일 노션에 수정했슴다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Presigned URL 기반 사진 업로드 워크플로 도입(업로드 URL 발급 및 업로드 결과 보고)
  * 사진 상태 추적 도입(UPLOADING → PROCESSING → COMPLETED/FAILED)
  * 업로드 파일 유효성 검사 및 앨범 참가자 권한 확인 강화(부분 성공/실패 보고 및 충돌 처리)
  * 앨범 사진 수의 원자적 증감 지원 및 업로드 관련 응답/오류 코드 추가
  * 관련 REST API 및 OpenAPI 문서 추가

* **Chores**
  * S3 연동 지원 추가(클라이언트·서명자 구성 및 AWS SDK 의존성 추가)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->