### PR TITLE
feat: 썸네일 생성 및 callback API 구현

### DIFF
--- a/src/main/java/com/cheeeese/global/common/code/SuccessCode.java
+++ b/src/main/java/com/cheeeese/global/common/code/SuccessCode.java
@@ -29,6 +29,7 @@ public enum SuccessCode implements BaseCode {
     PHOTO_AVAILABLE_COUNT_FETCH_SUCCESS(HttpStatus.OK, "업로드 가능 사진 수 조회가 성공적으로 완료되었습니다."),
     PRESIGNED_URL_ISSUE_SUCCESS(HttpStatus.OK, "Presigned URL 발급이 성공적으로 완료되었습니다."),
     PHOTO_UPLOAD_REPORT_SUCCESS(HttpStatus.OK, "사진 업로드 결과 보고가 성공적으로 처리되었습니다."),
+    THUMBNAIL_PRODUCE_COMPLETE(HttpStatus.OK, "썸네일 생성이 성공적으로 완료되었습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/cheeeese/global/config/SecurityConfig.java
+++ b/src/main/java/com/cheeeese/global/config/SecurityConfig.java
@@ -36,7 +36,8 @@ public class SecurityConfig {
             "/login/oauth2/**",
             "/v1/auth/exchange",
             "/v1/auth/reissue",
-            "/v1/album/*/invitation"
+            "/v1/album/*/invitation",
+            "/internal/thumbnail/complete"
     };
 
     @Bean

--- a/src/main/java/com/cheeeese/photo/application/PhotoCallbackService.java
+++ b/src/main/java/com/cheeeese/photo/application/PhotoCallbackService.java
@@ -1,6 +1,7 @@
 package com.cheeeese.photo.application;
 
 import com.cheeeese.photo.domain.PhotoStatus;
+import com.cheeeese.photo.dto.request.PhotoCompleteRequest;
 import com.cheeeese.photo.exception.PhotoException;
 import com.cheeeese.photo.exception.code.PhotoErrorCode;
 import com.cheeeese.photo.infrastructure.persistence.PhotoRepository;
@@ -15,10 +16,16 @@ public class PhotoCallbackService {
 
     private final PhotoRepository photoRepository;
 
-    public void markUploadCompleted(Long photoId) {
-        int updated = photoRepository.updateStatus(photoId, PhotoStatus.COMPLETED);
+    public void markUploadCompleted(PhotoCompleteRequest request) {
+        int updated = photoRepository.updateStatusAndUrl(
+                request.photoId(),
+                PhotoStatus.UPLOADING,
+                PhotoStatus.COMPLETED,
+                request.thumbnailUrl()
+        );
+
         if (updated == 0) {
-            throw new PhotoException(PhotoErrorCode.PHOTO_ID_NOT_FOUND);
+            throw new PhotoException(PhotoErrorCode.THUMBNAIL_UPDATE_FAILED);
         }
     }
 }

--- a/src/main/java/com/cheeeese/photo/application/PhotoCallbackService.java
+++ b/src/main/java/com/cheeeese/photo/application/PhotoCallbackService.java
@@ -19,7 +19,7 @@ public class PhotoCallbackService {
     public void markUploadCompleted(PhotoCompleteRequest request) {
         int updated = photoRepository.updateStatusAndUrl(
                 request.photoId(),
-                PhotoStatus.UPLOADING,
+                PhotoStatus.PROCESSING,
                 PhotoStatus.COMPLETED,
                 request.thumbnailUrl()
         );

--- a/src/main/java/com/cheeeese/photo/application/PhotoCallbackService.java
+++ b/src/main/java/com/cheeeese/photo/application/PhotoCallbackService.java
@@ -1,0 +1,24 @@
+package com.cheeeese.photo.application;
+
+import com.cheeeese.photo.domain.PhotoStatus;
+import com.cheeeese.photo.exception.PhotoException;
+import com.cheeeese.photo.exception.code.PhotoErrorCode;
+import com.cheeeese.photo.infrastructure.persistence.PhotoRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class PhotoCallbackService {
+
+    private final PhotoRepository photoRepository;
+
+    public void markUploadCompleted(Long photoId) {
+        int updated = photoRepository.updateStatus(photoId, PhotoStatus.COMPLETED);
+        if (updated == 0) {
+            throw new PhotoException(PhotoErrorCode.PHOTO_ID_NOT_FOUND);
+        }
+    }
+}

--- a/src/main/java/com/cheeeese/photo/domain/Photo.java
+++ b/src/main/java/com/cheeeese/photo/domain/Photo.java
@@ -31,6 +31,9 @@ public class Photo extends BaseEntity {
     @Column(name = "image_url", nullable = true, columnDefinition = "TEXT")
     private String imageUrl;
 
+    @Column(name = "thumbnail_url", columnDefinition = "TEXT")
+    private String thumbnailUrl;
+
     @Column(name = "likes_cnt", nullable = false)
     private int likesCnt;
 
@@ -49,12 +52,14 @@ public class Photo extends BaseEntity {
             Long userId,
             Long albumId,
             String imageUrl,
+            String thumbnailUrl,
             LocalDateTime captureTime,
             PhotoStatus status
     ) {
         this.userId = userId;
         this.albumId = albumId;
         this.imageUrl = imageUrl;
+        this.thumbnailUrl = thumbnailUrl;
         this.captureTime = captureTime;
         this.likesCnt = 0;
         this.isDeleted = false;

--- a/src/main/java/com/cheeeese/photo/dto/request/PhotoCompleteRequest.java
+++ b/src/main/java/com/cheeeese/photo/dto/request/PhotoCompleteRequest.java
@@ -1,5 +1,12 @@
 package com.cheeeese.photo.dto.request;
 
+
+import jakarta.validation.constraints.NotNull;
+
 public record PhotoCompleteRequest(
-        Long photoId
+        @NotNull(message = "photoId는 필수입니다")
+        Long photoId,
+
+        @NotNull(message = "thumbnailUrl은 필수입니다")
+        String thumbnailUrl
 ) {}

--- a/src/main/java/com/cheeeese/photo/dto/request/PhotoCompleteRequest.java
+++ b/src/main/java/com/cheeeese/photo/dto/request/PhotoCompleteRequest.java
@@ -1,0 +1,5 @@
+package com.cheeeese.photo.dto.request;
+
+public record PhotoCompleteRequest(
+        Long photoId
+) {}

--- a/src/main/java/com/cheeeese/photo/exception/code/PhotoErrorCode.java
+++ b/src/main/java/com/cheeeese/photo/exception/code/PhotoErrorCode.java
@@ -25,6 +25,7 @@ public enum PhotoErrorCode implements BaseCode {
     PHOTO_REPORT_CONFLICTING_IDS(HttpStatus.BAD_REQUEST, "업로드 결과(success/failure) 목록에 중복된 사진 ID가 포함되어 있습니다."),
     PHOTO_STATUS_UPDATE_FAILED(HttpStatus.CONFLICT, "사진 상태 업데이트에 실패했습니다."),
     PHOTO_COUNT_DECREMENT_FAILED(HttpStatus.CONFLICT, "앨범 사진 개수 감소에 실패했습니다."),
+    THUMBNAIL_UPDATE_FAILED(HttpStatus.CONFLICT, "썸네일 상태 업데이트에 실패했습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/cheeeese/photo/infrastructure/mapper/PhotoMapper.java
+++ b/src/main/java/com/cheeeese/photo/infrastructure/mapper/PhotoMapper.java
@@ -14,6 +14,7 @@ public class PhotoMapper {
                 .userId(userId)
                 .albumId(albumId)
                 .imageUrl(null) // presigned URL 생성 후 updateImageUrl()로 세팅됨
+                .thumbnailUrl(null)
                 .captureTime(LocalDateTime.now())
                 .status(PhotoStatus.UPLOADING)
                 .build();

--- a/src/main/java/com/cheeeese/photo/infrastructure/persistence/PhotoRepository.java
+++ b/src/main/java/com/cheeeese/photo/infrastructure/persistence/PhotoRepository.java
@@ -30,7 +30,8 @@ public interface PhotoRepository extends JpaRepository<Photo, Long> {
             @Param("expectedStatus") PhotoStatus expectedStatus
     );
 
-    @Modifying
-    @Query("UPDATE Photo p SET p.status = :status WHERE p.id = :photoId")
-    int updateStatus(Long photoId, PhotoStatus status);
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("update Photo p set p.status = :newStatus, p.thumbnailUrl = :thumbnailUrl " +
+            "where p.id = :photoId and p.status = :expectedStatus")
+    int updateStatusAndUrl(Long photoId, PhotoStatus expectedStatus, PhotoStatus newStatus, String thumbnailUrl);
 }

--- a/src/main/java/com/cheeeese/photo/infrastructure/persistence/PhotoRepository.java
+++ b/src/main/java/com/cheeeese/photo/infrastructure/persistence/PhotoRepository.java
@@ -29,4 +29,8 @@ public interface PhotoRepository extends JpaRepository<Photo, Long> {
             @Param("newStatus") PhotoStatus newStatus,
             @Param("expectedStatus") PhotoStatus expectedStatus
     );
+
+    @Modifying
+    @Query("UPDATE Photo p SET p.status = :status WHERE p.id = :photoId")
+    int updateStatus(Long photoId, PhotoStatus status);
 }

--- a/src/main/java/com/cheeeese/photo/presentation/PhotoCallbackController.java
+++ b/src/main/java/com/cheeeese/photo/presentation/PhotoCallbackController.java
@@ -1,0 +1,24 @@
+package com.cheeeese.photo.presentation;
+
+import com.cheeeese.global.common.CommonResponse;
+import com.cheeeese.photo.dto.request.PhotoCompleteRequest;
+import com.cheeeese.photo.application.PhotoCallbackService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import static com.cheeeese.global.common.code.SuccessCode.THUMBNAIL_PRODUCE_COMPLETE;
+
+@RestController
+@RequestMapping("/internal/thumbnail")
+@RequiredArgsConstructor
+public class PhotoCallbackController {
+
+    private final PhotoCallbackService photoCallbackService;
+
+    @PostMapping("/complete")
+    public CommonResponse<Void> completeUpload(@RequestBody PhotoCompleteRequest request) {
+        photoCallbackService.markUploadCompleted(request.photoId());
+        return CommonResponse.success(THUMBNAIL_PRODUCE_COMPLETE);
+    }
+}

--- a/src/main/java/com/cheeeese/photo/presentation/PhotoCallbackController.java
+++ b/src/main/java/com/cheeeese/photo/presentation/PhotoCallbackController.java
@@ -3,8 +3,8 @@ package com.cheeeese.photo.presentation;
 import com.cheeeese.global.common.CommonResponse;
 import com.cheeeese.photo.dto.request.PhotoCompleteRequest;
 import com.cheeeese.photo.application.PhotoCallbackService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import static com.cheeeese.global.common.code.SuccessCode.THUMBNAIL_PRODUCE_COMPLETE;
@@ -17,8 +17,8 @@ public class PhotoCallbackController {
     private final PhotoCallbackService photoCallbackService;
 
     @PostMapping("/complete")
-    public CommonResponse<Void> completeUpload(@RequestBody PhotoCompleteRequest request) {
-        photoCallbackService.markUploadCompleted(request.photoId());
+    public CommonResponse<Void> completeUpload(@Valid @RequestBody PhotoCompleteRequest request) {
+        photoCallbackService.markUploadCompleted(request);
         return CommonResponse.success(THUMBNAIL_PRODUCE_COMPLETE);
     }
 }


### PR DESCRIPTION
## 🔗 연관된 이슈
- #26 

## 🚀 변경 유형
- [x] ✨ 기능 추가 (feature)
- [ ] 🐛 버그 수정 (fix)
- [ ] 📝 문서 변경 (docs)
- [ ] ♻️ 리팩토링 (refactor)
- [ ] 🧪 테스트 추가 / 수정 (test)
- [ ] ⚙️ 설정 변경 (chore)

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- NCP에서 Object Storage에 PUT 이벤트를 트리거로 두고, action으로 썸네일 생성을 만들었습니다.
- 썸네일 생성이 완료되면 썸네일용 버킷(say-cheeeese-thumbnail)에 오리지널과 동일한 규칙으로 `album/{albumCode}/thumbnail/{photoId}_{imageName}` 으로 저장
- 저장 후 /internal/thumbnail/complete  api로 photoId를 담아서 서버로 보내줍니다. 
- 이후 서버에서 Photo 테이블의 상태를 complete로 바꾸게 됩니다.

## 📸 스크린샷
>
<img width="631" height="137" alt="스크린샷 2025-10-28 오후 11 20 21" src="https://github.com/user-attachments/assets/1e10e5cf-7853-4680-a6de-ff4cb6b8b2c2" />


## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 사진 업로드 완료를 수신하는 내부 콜백 엔드포인트가 추가되었습니다.
  * 썸네일 생성 완료 시 사진의 상태와 썸네일 URL이 자동으로 업데이트됩니다.
* **버그 수정**
  * 썸네일 업데이트 실패 시 명확한 오류 코드가 추가되어 장애 원인 파악이 개선됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->