### PR TITLE
feat: Photo, UserAlbum 엔티티에 Join 추가 및 NewEnterResponse 수정

### DIFF
--- a/src/main/java/com/cheeeese/album/application/AlbumService.java
+++ b/src/main/java/com/cheeeese/album/application/AlbumService.java
@@ -69,8 +69,8 @@ public class AlbumService {
         albumRepository.save(album);
 
         userAlbumRepository.save(UserAlbumMapper.toEntity(
-                user.getId(),
-                album.getId(),
+                user,
+                album,
                 Role.MAKER
         ));
 
@@ -110,8 +110,11 @@ public class AlbumService {
 
         // Case 2: 신규 참여
         albumValidator.validateAlbumCapacity(album);
-        UserAlbum newUserAlbum = UserAlbumMapper.toGuestUserAlbum(currentUser, album);
-        userAlbumRepository.save(newUserAlbum);
+        userAlbumRepository.save(UserAlbumMapper.toEntity(
+                currentUser,
+                album,
+                Role.MAKER
+        ));
 
         int updated = albumRepository.incrementParticipantCountAtomically(album.getId());
         if (updated == 0) {

--- a/src/main/java/com/cheeeese/album/application/AlbumService.java
+++ b/src/main/java/com/cheeeese/album/application/AlbumService.java
@@ -5,8 +5,7 @@ import com.cheeeese.album.domain.Album;
 import com.cheeeese.album.domain.type.AlbumJoinStatus;
 import com.cheeeese.album.domain.type.Role;
 import com.cheeeese.album.dto.request.AlbumCreationRequest;
-import com.cheeeese.album.dto.response.AlbumCreationResponse;
-import com.cheeeese.album.dto.response.AlbumInvitationResponse;
+import com.cheeeese.album.dto.response.*;
 import com.cheeeese.album.exception.AlbumException;
 import com.cheeeese.album.exception.code.AlbumErrorCode;
 import com.cheeeese.album.infrastructure.mapper.AlbumMapper;
@@ -14,10 +13,8 @@ import com.cheeeese.album.infrastructure.mapper.UserAlbumMapper;
 import com.cheeeese.album.infrastructure.persistence.AlbumRepository;
 import com.cheeeese.photo.application.PhotoService;
 import com.cheeeese.album.domain.UserAlbum;
-import com.cheeeese.album.dto.response.AlbumEnterResponse;
-import com.cheeeese.album.dto.response.AlbumMakerInfo;
-import com.cheeeese.album.dto.response.UploadAvailableCountResponse;
 import com.cheeeese.album.infrastructure.persistence.UserAlbumRepository;
+import com.cheeeese.photo.domain.Photo;
 import com.cheeeese.user.domain.User;
 import com.cheeeese.user.exception.UserException;
 import com.cheeeese.user.exception.code.UserErrorCode;
@@ -34,6 +31,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -121,11 +119,11 @@ public class AlbumService {
             throw new AlbumException(AlbumErrorCode.ALBUM_MAX_PARTICIPANT_REACHED);
         }
 
-        List<String> recentThumbnails = photoService.getRecentThumbnailUrls(album.getId());
+        List<NewEnterResponse.RecentPhotoResponse> recentPhotos = getRecentPhotosWithUploaderInfo(album.getId());
 
         int remainingUploadSlots = calculateRemainingUploadSlots(album);
 
-        return AlbumMapper.toNewResponse(album, makerInfo, remainingUploadSlots, recentThumbnails);
+        return AlbumMapper.toNewResponse(album, makerInfo, remainingUploadSlots, recentPhotos);
     }
 
     public UploadAvailableCountResponse getAvailablePhotoCount(User user, String code) {
@@ -158,5 +156,24 @@ public class AlbumService {
     private User getMaker(Long makerId) {
         return userRepository.findById(makerId)
                 .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+    }
+
+    private List<NewEnterResponse.RecentPhotoResponse> getRecentPhotosWithUploaderInfo(Long albumId) {
+        List<Photo> photos = photoService.getRecentPhotosForNewEnter(albumId);
+
+        if (photos.isEmpty()) {
+            return List.of();
+        }
+
+        // 1~4개인 경우, 1개만 반환하는 비즈니스 로직 적용
+        if (photos.size() < 5) {
+            Photo photo = photos.get(0);
+            return List.of(AlbumMapper.toRecentPhotoResponse(photo));
+        }
+
+        // 5개인 경우, 5개 모두 반환
+        return photos.stream()
+                .map(AlbumMapper::toRecentPhotoResponse)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/cheeeese/album/application/AlbumService.java
+++ b/src/main/java/com/cheeeese/album/application/AlbumService.java
@@ -111,7 +111,7 @@ public class AlbumService {
         userAlbumRepository.save(UserAlbumMapper.toEntity(
                 currentUser,
                 album,
-                Role.MAKER
+                Role.GUEST
         ));
 
         int updated = albumRepository.incrementParticipantCountAtomically(album.getId());

--- a/src/main/java/com/cheeeese/album/domain/UserAlbum.java
+++ b/src/main/java/com/cheeeese/album/domain/UserAlbum.java
@@ -2,6 +2,7 @@ package com.cheeeese.album.domain;
 
 import com.cheeeese.album.domain.type.Role;
 import com.cheeeese.global.domain.BaseEntity;
+import com.cheeeese.user.domain.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -19,13 +20,13 @@ public class UserAlbum extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    // TODO: 추후 필요시 ManyToOne, JoinColumn 넣을 예정
-    @Column(name = "user_id", nullable = false)
-    private Long userId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
 
-    // TODO: 추후 필요시 ManyToOne, JoinColumn 넣을 예정
-    @Column(name = "album_id", nullable = false)
-    private Long albumId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "album_id", nullable = false)
+    private Album album;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "role", nullable = false)
@@ -35,9 +36,9 @@ public class UserAlbum extends BaseEntity {
     private boolean isVisible;
 
     @Builder
-    private UserAlbum(Long userId, Long albumId, Role role, boolean isVisible) {
-        this.userId = userId;
-        this.albumId = albumId;
+    private UserAlbum(User user, Album album, Role role, boolean isVisible) {
+        this.user = user;
+        this.album = album;
         this.role = role;
         this.isVisible = isVisible;
     }

--- a/src/main/java/com/cheeeese/album/dto/response/NewEnterResponse.java
+++ b/src/main/java/com/cheeeese/album/dto/response/NewEnterResponse.java
@@ -2,6 +2,7 @@ package com.cheeeese.album.dto.response;
 
 import com.cheeeese.album.domain.type.AlbumJoinStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
@@ -31,6 +32,22 @@ public record NewEnterResponse(
         @Schema(description = "남은 업로드 가능 사진 수", example = "5")
         Integer remainingUploadSlots,
 
-        @Schema(description = "최근 업로드된 사진 썸네일 URL 목록 (최대 5개)", example = "[\"https://cdn.cheeeese.com/album/1/thumb1.jpg\"]")
-        List<String> recentPhotoUrls
-) implements AlbumEnterResponse {}
+        @Schema(description = "최근 업로드된 사진 목록 (최대 5개)", implementation = RecentPhotoResponse.class)
+        List<RecentPhotoResponse> recentPhotos
+) implements AlbumEnterResponse {
+        @Builder
+        @Schema(description = "최근 업로드 사진 정보 DTO")
+        public record RecentPhotoResponse(
+                @NotNull
+                @Schema(description = "사진 썸네일 URL", example = "https://cdn.cheeeese.com/album/1/thumb1.jpg")
+                String thumbnailUrl,
+
+                @NotNull
+                @Schema(description = "업로드 사용자 이름", example = "김치즈")
+                String uploaderName,
+
+                @NotNull
+                @Schema(description = "업로드 사용자 프로필 이미지 URL", example = "https://cdn.cheeeese.com/user/1/profile.jpg")
+                String uploaderProfileImage
+        ) {}
+}

--- a/src/main/java/com/cheeeese/album/infrastructure/mapper/AlbumMapper.java
+++ b/src/main/java/com/cheeeese/album/infrastructure/mapper/AlbumMapper.java
@@ -3,6 +3,7 @@ package com.cheeeese.album.infrastructure.mapper;
 import com.cheeeese.album.domain.Album;
 import com.cheeeese.album.domain.type.AlbumJoinStatus;
 import com.cheeeese.album.dto.response.*;
+import com.cheeeese.photo.domain.Photo;
 import com.cheeeese.user.domain.User;
 
 import java.time.LocalDate;
@@ -100,7 +101,7 @@ public class AlbumMapper {
             Album album,
             AlbumMakerInfo makerInfo,
             int remainingUploadSlots,
-            List<String> recentPhotoUrls
+            List<NewEnterResponse.RecentPhotoResponse> recentPhotos
     ) {
         return NewEnterResponse.builder()
                 .joinStatus(AlbumJoinStatus.NEW)
@@ -110,7 +111,17 @@ public class AlbumMapper {
                 .expiredAt(album.getExpiredAt())
                 .makerInfo(makerInfo)
                 .remainingUploadSlots(remainingUploadSlots)
-                .recentPhotoUrls(recentPhotoUrls)
+                .recentPhotos(recentPhotos)
+                .build();
+    }
+
+    public static NewEnterResponse.RecentPhotoResponse toRecentPhotoResponse(Photo photo) {
+        User uploader = photo.getUser();
+
+        return NewEnterResponse.RecentPhotoResponse.builder()
+                .thumbnailUrl(photo.getThumbnailUrl())
+                .uploaderName(uploader.getName())
+                .uploaderProfileImage(uploader.getProfileImage())
                 .build();
     }
 

--- a/src/main/java/com/cheeeese/album/infrastructure/mapper/UserAlbumMapper.java
+++ b/src/main/java/com/cheeeese/album/infrastructure/mapper/UserAlbumMapper.java
@@ -7,23 +7,11 @@ import com.cheeeese.user.domain.User;
 
 public class UserAlbumMapper {
 
-    public static UserAlbum toEntity(Long userId, Long albumId, Role role) {
+    public static UserAlbum toEntity(User user, Album album, Role role) {
         return UserAlbum.builder()
-                .userId(userId)
-                .albumId(albumId)
+                .user(user)
+                .album(album)
                 .role(role)
-                .isVisible(true)
-                .build();
-    }
-
-    /**
-     * User와 Album 엔티티를 기반으로 GUEST 역할의 UserAlbum 엔티티를 생성합니다.
-     */
-    public static UserAlbum toGuestUserAlbum(User user, Album album) {
-        return UserAlbum.builder()
-                .userId(user.getId())
-                .albumId(album.getId())
-                .role(Role.GUEST)
                 .isVisible(true)
                 .build();
     }

--- a/src/main/java/com/cheeeese/album/infrastructure/persistence/UserAlbumRepository.java
+++ b/src/main/java/com/cheeeese/album/infrastructure/persistence/UserAlbumRepository.java
@@ -3,14 +3,19 @@ package com.cheeeese.album.infrastructure.persistence;
 import com.cheeeese.album.domain.UserAlbum;
 import com.cheeeese.album.domain.type.Role;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface UserAlbumRepository extends JpaRepository<UserAlbum, Long> {
-    Optional<UserAlbum> findByUserIdAndAlbumId(Long userId, Long albumId);
+    @Query("SELECT ua FROM UserAlbum ua WHERE ua.user.id = :userId AND ua.album.id = :albumId")
+    Optional<UserAlbum> findByUserIdAndAlbumId(@Param("userId") Long userId, @Param("albumId") Long albumId);
 
-    List<UserAlbum> findAllByAlbumId(Long albumId);
+    @Query("SELECT ua FROM UserAlbum ua WHERE ua.album.id = :albumId")
+    List<UserAlbum> findAllByAlbumId(@Param("albumId") Long albumId);
 
-    Optional<UserAlbum> findByAlbumIdAndUserIdAndRole(Long albumId, Long userId, Role role);
+    @Query("SELECT ua FROM UserAlbum ua WHERE ua.album.id = :albumId AND ua.user.id = :userId AND ua.role = :role")
+    Optional<UserAlbum> findByAlbumIdAndUserIdAndRole(@Param("albumId") Long albumId, @Param("userId") Long userId, @Param("role") Role role);
 }

--- a/src/main/java/com/cheeeese/photo/application/PhotoService.java
+++ b/src/main/java/com/cheeeese/photo/application/PhotoService.java
@@ -36,24 +36,12 @@ public class PhotoService {
 
     private static final String ORIGINAL_PHOTO_PATH_FORMAT = "album/%s/original/%d_%s";
 
-    public List<String> getRecentThumbnailUrls(Long albumId) {
-        List<Photo> photos = photoRepository.findRecentPhotosByAlbumIdAndStatus(
+    public List<Photo> getRecentPhotosForNewEnter(Long albumId) {
+        return photoRepository.findRecentPhotosByAlbumIdAndStatus(
                 albumId,
                 PhotoStatus.COMPLETED,
                 PageRequest.of(0, 5)
         );
-
-        if (photos.isEmpty()) {
-            return List.of();
-        }
-
-        if (photos.size() < 5) {
-            return List.of(photos.get(0).getThumbnailUrl());
-        }
-
-        return photos.stream()
-                .map(Photo::getThumbnailUrl)
-                .collect(Collectors.toList());
     }
 
     @Transactional

--- a/src/main/java/com/cheeeese/photo/application/PhotoService.java
+++ b/src/main/java/com/cheeeese/photo/application/PhotoService.java
@@ -15,6 +15,7 @@ import com.cheeeese.photo.infrastructure.mapper.PhotoMapper;
 import com.cheeeese.photo.infrastructure.persistence.PhotoRepository;
 import com.cheeeese.user.domain.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -36,8 +37,11 @@ public class PhotoService {
     private static final String ORIGINAL_PHOTO_PATH_FORMAT = "album/%s/original/%d_%s";
 
     public List<String> getRecentThumbnailUrls(Long albumId) {
-        List<Photo> photos = photoRepository
-                .findTop5ByAlbumIdAndIsDeletedFalseAndStatusOrderByCreatedAtDesc(albumId, PhotoStatus.COMPLETED);
+        List<Photo> photos = photoRepository.findRecentPhotosByAlbumIdAndStatus(
+                albumId,
+                PhotoStatus.COMPLETED,
+                PageRequest.of(0, 5)
+        );
 
         if (photos.isEmpty()) {
             return List.of();
@@ -106,7 +110,7 @@ public class PhotoService {
             Album album,
             PhotoPresignedUrlRequest.FileInfo file
     ) {
-        Photo photo = PhotoMapper.toEntity(user.getId(), album.getId());
+        Photo photo = PhotoMapper.toEntity(user, album);
         photoRepository.save(photo);
 
         String safeFileName = sanitizeFileName(file.fileName());

--- a/src/main/java/com/cheeeese/photo/application/validator/PhotoValidator.java
+++ b/src/main/java/com/cheeeese/photo/application/validator/PhotoValidator.java
@@ -103,7 +103,7 @@ public class PhotoValidator {
      */
     private void validateOwnership(List<Photo> photos, Long userId) {
         boolean invalidOwner = photos.stream()
-                .anyMatch(photo -> !photo.getUserId().equals(userId));
+                .anyMatch(photo -> !photo.getUser().getId().equals(userId));
 
         if (invalidOwner) {
             throw new PhotoException(PhotoErrorCode.PHOTO_OWNER_MISMATCH);
@@ -115,7 +115,7 @@ public class PhotoValidator {
      */
     private Long validateSingleAlbum(List<Photo> photos) {
         Set<Long> albumIds = photos.stream()
-                .map(Photo::getAlbumId)
+                .map(photo -> photo.getAlbum().getId())
                 .collect(Collectors.toSet());
 
         if (albumIds.size() != 1) {

--- a/src/main/java/com/cheeeese/photo/domain/Photo.java
+++ b/src/main/java/com/cheeeese/photo/domain/Photo.java
@@ -1,6 +1,8 @@
 package com.cheeeese.photo.domain;
 
+import com.cheeeese.album.domain.Album;
 import com.cheeeese.global.domain.BaseEntity;
+import com.cheeeese.user.domain.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -20,15 +22,15 @@ public class Photo extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    // TODO: 추후 필요시 ManyToOne, JoinColumn 넣을 예정
-    @Column(name = "user_id", nullable = false)
-    private Long userId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
 
-    // TODO: 추후 필요시 ManyToOne, JoinColumn 넣을 예정
-    @Column(name = "album_id", nullable = false)
-    private Long albumId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "album_id", nullable = false)
+    private Album album;
 
-    @Column(name = "image_url", nullable = true, columnDefinition = "TEXT")
+    @Column(name = "image_url", columnDefinition = "TEXT")
     private String imageUrl;
 
     @Column(name = "thumbnail_url", columnDefinition = "TEXT")
@@ -49,15 +51,15 @@ public class Photo extends BaseEntity {
 
     @Builder
     private Photo(
-            Long userId,
-            Long albumId,
+            User user,
+            Album album,
             String imageUrl,
             String thumbnailUrl,
             LocalDateTime captureTime,
             PhotoStatus status
     ) {
-        this.userId = userId;
-        this.albumId = albumId;
+        this.user = user;
+        this.album = album;
         this.imageUrl = imageUrl;
         this.thumbnailUrl = thumbnailUrl;
         this.captureTime = captureTime;

--- a/src/main/java/com/cheeeese/photo/infrastructure/mapper/PhotoMapper.java
+++ b/src/main/java/com/cheeeese/photo/infrastructure/mapper/PhotoMapper.java
@@ -1,18 +1,20 @@
 package com.cheeeese.photo.infrastructure.mapper;
 
+import com.cheeeese.album.domain.Album;
 import com.cheeeese.photo.domain.Photo;
 import com.cheeeese.photo.domain.PhotoStatus;
 import com.cheeeese.photo.dto.response.PhotoPresignedUrlResponse;
+import com.cheeeese.user.domain.User;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 public class PhotoMapper {
 
-    public static Photo toEntity(Long userId, Long albumId) {
+    public static Photo toEntity(User user, Album album) {
         return Photo.builder()
-                .userId(userId)
-                .albumId(albumId)
+                .user(user)
+                .album(album)
                 .imageUrl(null) // presigned URL 생성 후 updateImageUrl()로 세팅됨
                 .thumbnailUrl(null)
                 .captureTime(LocalDateTime.now())

--- a/src/main/java/com/cheeeese/photo/infrastructure/persistence/PhotoRepository.java
+++ b/src/main/java/com/cheeeese/photo/infrastructure/persistence/PhotoRepository.java
@@ -2,6 +2,7 @@ package com.cheeeese.photo.infrastructure.persistence;
 
 import com.cheeeese.photo.domain.Photo;
 import com.cheeeese.photo.domain.PhotoStatus;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -11,16 +12,26 @@ import java.util.List;
 
 public interface PhotoRepository extends JpaRepository<Photo, Long> {
 
-    List<Photo> findTop5ByAlbumIdAndIsDeletedFalseAndStatusOrderByCreatedAtDesc(
-            Long albumId,
-            PhotoStatus status
+    @Query("""
+        SELECT p 
+        FROM Photo p 
+        WHERE p.album.id = :albumId 
+        AND p.isDeleted = FALSE 
+        AND p.status = :status
+        ORDER BY p.createdAt DESC
+    """)
+    List<Photo> findRecentPhotosByAlbumIdAndStatus(
+            @Param("albumId") Long albumId,
+            @Param("status") PhotoStatus status,
+            Pageable pageable
     );
+
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("""
         UPDATE Photo p
         SET p.status = :newStatus
         WHERE p.id IN :photoIds
-        AND p.userId = :userId
+        AND p.user.id = :userId
         AND p.status = :expectedStatus
     """)
     int updateStatusByIdsAndUserIdAndExpectedStatus(

--- a/src/main/java/com/cheeeese/photo/infrastructure/persistence/PhotoRepository.java
+++ b/src/main/java/com/cheeeese/photo/infrastructure/persistence/PhotoRepository.java
@@ -15,6 +15,7 @@ public interface PhotoRepository extends JpaRepository<Photo, Long> {
     @Query("""
         SELECT p 
         FROM Photo p 
+        JOIN FETCH p.user
         WHERE p.album.id = :albumId 
         AND p.isDeleted = FALSE 
         AND p.status = :status


### PR DESCRIPTION
## 🔗 연관된 이슈
- #34 

## 🚀 변경 유형
- [x] ✨ 기능 추가 (feature)
- [x] 🐛 버그 수정 (fix)
- [ ] 📝 문서 변경 (docs)
- [ ] ♻️ 리팩토링 (refactor)
- [ ] 🧪 테스트 추가 / 수정 (test)
- [ ] ⚙️ 설정 변경 (chore)

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- joinColumn 어노테이션 추가
- 어노테이션 추가에 따른 service, repository, mapper 코드 수정
- NewEnterResponse 응답에 사용자 이름, 이미지 url 포함되도록 수정

## 📸 스크린샷
>
<img width="561" height="480" alt="스크린샷 2025-11-01 오전 1 28 59" src="https://github.com/user-attachments/assets/eea307ca-7d00-4dde-801c-6898b2128d03" />


## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
- +)) User 테이블에 album_cnt 가 있는데 앨범 생성할 떄 이 필드가 그대로 입니다. 나중에 구현 부탁드려요~
- *나도 photo_cnt 올리는 로직을 까먹었다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 앨범 진입 시 최근 업로드 사진에 업로더 이름과 프로필 이미지가 함께 표시됩니다 (최대 5개).

* **리팩터**
  * 앨범·사진 데이터 구조 개선 및 저장소 조회 최적화로 최신 사진 조회 안정성 및 성능 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->