### PR TITLE
fix: photo status 관련 로직 수정

### DIFF
--- a/src/main/java/com/cheeeese/photo/application/PhotoCallbackService.java
+++ b/src/main/java/com/cheeeese/photo/application/PhotoCallbackService.java
@@ -19,7 +19,7 @@ public class PhotoCallbackService {
     public void markUploadCompleted(PhotoCompleteRequest request) {
         int updated = photoRepository.updateStatusAndUrl(
                 request.photoId(),
-                PhotoStatus.PROCESSING,
+                PhotoStatus.UPLOADING,
                 PhotoStatus.COMPLETED,
                 request.thumbnailUrl()
         );

--- a/src/main/java/com/cheeeese/photo/application/PhotoService.java
+++ b/src/main/java/com/cheeeese/photo/application/PhotoService.java
@@ -13,6 +13,7 @@ import com.cheeeese.photo.exception.PhotoException;
 import com.cheeeese.photo.exception.code.PhotoErrorCode;
 import com.cheeeese.photo.infrastructure.mapper.PhotoMapper;
 import com.cheeeese.photo.infrastructure.persistence.PhotoRepository;
+import com.cheeeese.user.application.UserService;
 import com.cheeeese.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -28,6 +29,7 @@ import java.util.stream.Collectors;
 @Transactional(readOnly = true)
 public class PhotoService {
 
+    private final UserService userService;
     private final PhotoRepository photoRepository;
     private final PhotoValidator photoValidator;
     private final AlbumValidator albumValidator;
@@ -59,7 +61,7 @@ public class PhotoService {
             throw new PhotoException(PhotoErrorCode.PHOTO_COUNT_INCREMENT_FAILED);
         }
 
-        user.incrementPhotoCount(uploadCount);
+        userService.incrementPhotoCount(user.getId(), uploadCount);
 
         List<PhotoPresignedUrlResponse.PresignedUrlInfo> presignedUrls = generatePresignedUrls(user, album, request.fileInfos());
         return PhotoMapper.toPresignedUrlResponse(presignedUrls);
@@ -148,7 +150,7 @@ public class PhotoService {
         }
 
         if (updatedRows > 0) {
-            user.decrementPhotoCount(updatedRows);
+            userService.decrementPhotoCount(user.getId(), updatedRows);
             int decremented = albumRepository.decrementPhotoCount(albumId, updatedRows);
             if (decremented == 0) {
                 throw new PhotoException(PhotoErrorCode.PHOTO_COUNT_DECREMENT_FAILED);

--- a/src/main/java/com/cheeeese/photo/application/PhotoService.java
+++ b/src/main/java/com/cheeeese/photo/application/PhotoService.java
@@ -52,10 +52,14 @@ public class PhotoService {
         Album album = validateAlbumAndPermission(user, request.albumCode());
         validateUploadRequest(album, request);
 
-        int updatedRows = albumRepository.incrementPhotoCount(album.getId(), request.fileInfos().size());
+        int uploadCount = request.fileInfos().size();
+
+        int updatedRows = albumRepository.incrementPhotoCount(album.getId(), uploadCount);
         if (updatedRows != 1) {
             throw new PhotoException(PhotoErrorCode.PHOTO_COUNT_INCREMENT_FAILED);
         }
+
+        user.incrementPhotoCount(uploadCount);
 
         List<PhotoPresignedUrlResponse.PresignedUrlInfo> presignedUrls = generatePresignedUrls(user, album, request.fileInfos());
         return PhotoMapper.toPresignedUrlResponse(presignedUrls);
@@ -70,7 +74,7 @@ public class PhotoService {
         PhotoValidator.ValidatedPhotos validated = photoValidator.validatePhotos(user.getId(), failurePhotoIds);
         Long albumId = validated.albumId();
 
-        handleFailedUploads(user.getId(), albumId, failurePhotoIds);
+        handleFailedUploads(user, albumId, failurePhotoIds);
     }
 
     private Album validateAlbumAndPermission(User user, String albumCode) {
@@ -131,10 +135,10 @@ public class PhotoService {
         return name;
     }
 
-    private void handleFailedUploads(Long userId, Long albumId, List<Long> failurePhotoIds) {
+    private void handleFailedUploads(User user, Long albumId, List<Long> failurePhotoIds) {
         int updatedRows = photoRepository.updateStatusByIdsAndUserIdAndExpectedStatus(
                 failurePhotoIds,
-                userId,
+                user.getId(),
                 PhotoStatus.FAILED,
                 PhotoStatus.UPLOADING
         );
@@ -144,6 +148,7 @@ public class PhotoService {
         }
 
         if (updatedRows > 0) {
+            user.decrementPhotoCount(updatedRows);
             int decremented = albumRepository.decrementPhotoCount(albumId, updatedRows);
             if (decremented == 0) {
                 throw new PhotoException(PhotoErrorCode.PHOTO_COUNT_DECREMENT_FAILED);

--- a/src/main/java/com/cheeeese/photo/application/PhotoService.java
+++ b/src/main/java/com/cheeeese/photo/application/PhotoService.java
@@ -15,6 +15,7 @@ import com.cheeeese.photo.infrastructure.mapper.PhotoMapper;
 import com.cheeeese.photo.infrastructure.persistence.PhotoRepository;
 import com.cheeeese.user.domain.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -33,6 +34,9 @@ public class PhotoService {
     private final AlbumValidator albumValidator;
     private final AlbumRepository albumRepository;
     private final PresignedUrlService presignedUrlService;
+
+    @Value("${ncp.object-storage.bucket}")
+    private String bucket;
 
     private static final String ORIGINAL_PHOTO_PATH_FORMAT = "album/%s/original/%d_%s";
 
@@ -108,9 +112,10 @@ public class PhotoService {
                 photo.getId(),
                 safeFileName
         );
+        String imageUrl = bucket + "/" + objectKey;
+        photo.updateImageUrl(imageUrl);
 
         String uploadUrl = presignedUrlService.generatePresignedPutUrl(objectKey, file.contentType());
-        photo.updateImageUrl(objectKey);
 
         return PhotoMapper.toPresignedUrlInfo(photo.getId(), uploadUrl);
     }

--- a/src/main/java/com/cheeeese/photo/application/PhotoService.java
+++ b/src/main/java/com/cheeeese/photo/application/PhotoService.java
@@ -22,7 +22,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @Service
 @RequiredArgsConstructor
@@ -64,12 +63,14 @@ public class PhotoService {
 
     @Transactional
     public void reportUploadResult(User user, PhotoUploadReportRequest request) {
-        PhotoValidator.ValidatedPhotos validated = validateRequestAndPhotos(user, request);
+        List<Long> failurePhotoIds = request.failurePhotoIds().stream()
+                .distinct()
+                .toList();
+
+        PhotoValidator.ValidatedPhotos validated = photoValidator.validatePhotos(user.getId(), failurePhotoIds);
         Long albumId = validated.albumId();
 
-        handleSuccessfulUploads(user.getId(), request.successPhotoIds());
-
-        handleFailedUploads(user.getId(), albumId, request.failurePhotoIds());
+        handleFailedUploads(user.getId(), albumId, failurePhotoIds);
     }
 
     private Album validateAlbumAndPermission(User user, String albumCode) {
@@ -130,45 +131,7 @@ public class PhotoService {
         return name;
     }
 
-    private PhotoValidator.ValidatedPhotos validateRequestAndPhotos(User user, PhotoUploadReportRequest request) {
-        var success = new java.util.HashSet<>(request.successPhotoIds());
-        var failure = new java.util.HashSet<>(request.failurePhotoIds());
-        success.retainAll(failure);
-
-        if (!success.isEmpty()) {
-            throw new PhotoException(PhotoErrorCode.PHOTO_REPORT_CONFLICTING_IDS);
-        }
-
-        List<Long> allPhotoIds = Stream.concat(
-                request.successPhotoIds().stream(),
-                request.failurePhotoIds().stream()
-        ).toList();
-
-        return photoValidator.validatePhotos(user.getId(), allPhotoIds);
-    }
-
-    private void handleSuccessfulUploads(Long userId, List<Long> successPhotoIds) {
-        if (successPhotoIds == null || successPhotoIds.isEmpty()) {
-            return;
-        }
-
-        int updatedRows = photoRepository.updateStatusByIdsAndUserIdAndExpectedStatus(
-                successPhotoIds,
-                userId,
-                PhotoStatus.PROCESSING,
-                PhotoStatus.UPLOADING
-        );
-
-        if (updatedRows != successPhotoIds.size()) {
-            throw new PhotoException(PhotoErrorCode.PHOTO_STATUS_UPDATE_FAILED);
-        }
-    }
-
     private void handleFailedUploads(Long userId, Long albumId, List<Long> failurePhotoIds) {
-        if (failurePhotoIds == null || failurePhotoIds.isEmpty()) {
-            return;
-        }
-
         int updatedRows = photoRepository.updateStatusByIdsAndUserIdAndExpectedStatus(
                 failurePhotoIds,
                 userId,

--- a/src/main/java/com/cheeeese/photo/application/PhotoService.java
+++ b/src/main/java/com/cheeeese/photo/application/PhotoService.java
@@ -150,11 +150,11 @@ public class PhotoService {
         }
 
         if (updatedRows > 0) {
-            userService.decrementPhotoCount(user.getId(), updatedRows);
             int decremented = albumRepository.decrementPhotoCount(albumId, updatedRows);
             if (decremented == 0) {
                 throw new PhotoException(PhotoErrorCode.PHOTO_COUNT_DECREMENT_FAILED);
             }
+            userService.decrementPhotoCount(user.getId(), updatedRows);
         }
     }
 

--- a/src/main/java/com/cheeeese/photo/application/validator/PhotoValidator.java
+++ b/src/main/java/com/cheeeese/photo/application/validator/PhotoValidator.java
@@ -80,14 +80,15 @@ public class PhotoValidator {
      * photoId 리스트 기반으로 존재하는 사진 조회 및 존재 검증
      */
     private List<Photo> findAndValidateExistence(List<Long> photoIds) {
-        Set<Long> requestedIds = new HashSet<>(photoIds);
-        List<Photo> photos = photoRepository.findAllById(requestedIds);
+        List<Photo> photos = photoRepository.findAllById(photoIds);
+
+        Set<Long> uniqueRequestedIds = new HashSet<>(photoIds);
 
         Set<Long> foundIds = photos.stream()
                 .map(Photo::getId)
                 .collect(Collectors.toSet());
 
-        Set<Long> missingIds = requestedIds.stream()
+        Set<Long> missingIds = uniqueRequestedIds.stream()
                 .filter(id -> !foundIds.contains(id))
                 .collect(Collectors.toSet());
 

--- a/src/main/java/com/cheeeese/photo/domain/PhotoStatus.java
+++ b/src/main/java/com/cheeeese/photo/domain/PhotoStatus.java
@@ -2,7 +2,6 @@ package com.cheeeese.photo.domain;
 
 public enum PhotoStatus {
     UPLOADING,
-    PROCESSING,
     COMPLETED,
     FAILED
 }

--- a/src/main/java/com/cheeeese/photo/dto/request/PhotoUploadReportRequest.java
+++ b/src/main/java/com/cheeeese/photo/dto/request/PhotoUploadReportRequest.java
@@ -7,14 +7,10 @@ import lombok.Builder;
 import java.util.List;
 
 @Builder
-@Schema(description = "사진 업로드 결과 보고 요청 (부분 성공/실패 처리)")
+@Schema(description = "사진 업로드 결과 보고 요청 (실패 처리)")
 public record PhotoUploadReportRequest(
         @NotNull
-        @Schema(description = "업로드가 성공적으로 완료된 사진 ID 목록 (UPLOADING -> PROCESSING)", example = "[100, 102]")
-        List<Long> successPhotoIds,
-
-        @NotNull
-        @Schema(description = "업로드 중 실패하거나 취소된 사진 ID 목록 (UPLOADING -> FAILED & 롤백)", example = "[101, 103]")
+        @Schema(description = "업로드 중 실패하거나 취소된 사진 ID 목록 (PROCESSING -> FAILED & 롤백)", example = "[1, 3]")
         List<Long> failurePhotoIds
 ) {
 }

--- a/src/main/java/com/cheeeese/photo/dto/request/PhotoUploadReportRequest.java
+++ b/src/main/java/com/cheeeese/photo/dto/request/PhotoUploadReportRequest.java
@@ -10,7 +10,7 @@ import java.util.List;
 @Schema(description = "사진 업로드 결과 보고 요청 (실패 처리)")
 public record PhotoUploadReportRequest(
         @NotNull
-        @Schema(description = "업로드 중 실패하거나 취소된 사진 ID 목록 (PROCESSING -> FAILED & 롤백)", example = "[1, 3]")
+        @Schema(description = "업로드 중 실패하거나 취소된 사진 ID 목록 (UPLOADING -> FAILED & 롤백)", example = "[1, 3]")
         List<Long> failurePhotoIds
 ) {
 }

--- a/src/main/java/com/cheeeese/photo/presentation/swagger/PhotoSwagger.java
+++ b/src/main/java/com/cheeeese/photo/presentation/swagger/PhotoSwagger.java
@@ -74,17 +74,15 @@ public interface PhotoSwagger {
     );
 
     @Operation(
-            summary = "사진 업로드 결과 보고 API (부분 성공/실패 처리)", // [추가]
+            summary = "사진 업로드 결과 보고 API (실패 처리)", // [추가]
             description = """ 
                     ### RequestBody
                     ---
-                    `successPhotoIds`: Object Storage 업로드 성공 ID 목록 \n
                     `failurePhotoIds`: Object Storage 업로드 실패 ID 목록 \n
                     
                     ### 로직 상세
                     ---
-                    1. **Success IDs 처리**: `Photo` 상태를 `UPLOADING`에서 `PROCESSING`으로 변경 (후처리 대기).
-                    2. **Failure IDs 처리**: `Photo` 상태를 `UPLOADING`에서 `FAILED`으로 변경, 앨범의 `currentPhotoCount`를 **롤백** (감소)합니다.
+                    1. **Failure IDs 처리**: `Photo` 상태를 `UPLOADING`에서 `FAILED`으로 변경, 앨범의 `currentPhotoCount`를 **롤백** (감소)합니다.
                     """
     )
     @ApiResponses(value = {
@@ -102,20 +100,6 @@ public interface PhotoSwagger {
                           "isSuccess": false,
                           "code": 400,
                           "message": "보고된 사진들은 반드시 동일한 앨범에 속해야 합니다."
-                        }
-                        """)
-                    )
-            ),
-            @ApiResponse(
-                    responseCode = "400",
-                    description = "업로드 결과(success/failure) 목록에 중복된 사진 ID가 포함되어 있습니다.",
-                    content = @Content(
-                            mediaType = "application/json",
-                            schema = @Schema(example = """
-                        {
-                          "isSuccess": false,
-                          "code": 400,
-                          "message": "업로드 결과(success/failure) 목록에 중복된 사진 ID가 포함되어 있습니다."
                         }
                         """)
                     )

--- a/src/main/java/com/cheeeese/user/application/UserService.java
+++ b/src/main/java/com/cheeeese/user/application/UserService.java
@@ -4,6 +4,9 @@ import com.cheeeese.user.application.validator.UserValidator;
 import com.cheeeese.user.domain.User;
 import com.cheeeese.user.dto.request.UserAgreementRequest;
 import com.cheeeese.user.dto.request.UserProfileRequest;
+import com.cheeeese.user.exception.UserException;
+import com.cheeeese.user.exception.code.UserErrorCode;
+import com.cheeeese.user.infrastructure.persistence.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
 
     private final UserValidator userValidator;
+    private final UserRepository userRepository;
 
     @Transactional
     public void updateUserProfile(User user, UserProfileRequest request) {
@@ -32,5 +36,21 @@ public class UserService {
                 request.isMarketingAgreement(),
                 request.isThirdPartyAgreement()
         );
+    }
+
+    @Transactional
+    public void incrementPhotoCount(Long userId, int count) {
+        int updated = userRepository.incrementPhotoCount(userId, count);
+        if (updated != 1) {
+            throw new UserException(UserErrorCode.USER_PHOTO_COUNT_INCREMENT_FAILED);
+        }
+    }
+
+    @Transactional
+    public void decrementPhotoCount(Long userId, int count) {
+        int updated = userRepository.decrementPhotoCount(userId, count);
+        if (updated != 1) {
+            throw new UserException(UserErrorCode.USER_PHOTO_COUNT_DECREMENT_FAILED);
+        }
     }
 }

--- a/src/main/java/com/cheeeese/user/domain/User.java
+++ b/src/main/java/com/cheeeese/user/domain/User.java
@@ -99,4 +99,12 @@ public class User extends BaseEntity {
         this.isMarketingAgreement = isMarketingAgreement;
         this.isThirdPartyAgreement = isThirdPartyAgreement;
     }
+
+    public void incrementPhotoCount(int count) {
+        this.photoCnt += count;
+    }
+
+    public void decrementPhotoCount(int count) {
+        this.photoCnt -= count;
+    }
 }

--- a/src/main/java/com/cheeeese/user/domain/User.java
+++ b/src/main/java/com/cheeeese/user/domain/User.java
@@ -99,12 +99,4 @@ public class User extends BaseEntity {
         this.isMarketingAgreement = isMarketingAgreement;
         this.isThirdPartyAgreement = isThirdPartyAgreement;
     }
-
-    public void incrementPhotoCount(int count) {
-        this.photoCnt += count;
-    }
-
-    public void decrementPhotoCount(int count) {
-        this.photoCnt -= count;
-    }
 }

--- a/src/main/java/com/cheeeese/user/exception/code/UserErrorCode.java
+++ b/src/main/java/com/cheeeese/user/exception/code/UserErrorCode.java
@@ -11,6 +11,8 @@ public enum UserErrorCode implements BaseCode {
 
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다."),
     REQUIRED_TERMS_NOT_AGREED(HttpStatus.BAD_REQUEST, "필수 약관에 동의하지 않았습니다."),
+    USER_PHOTO_COUNT_INCREMENT_FAILED(HttpStatus.CONFLICT, "유저의 앨범 사진 개수 증가에 실패했습니다."),
+    USER_PHOTO_COUNT_DECREMENT_FAILED(HttpStatus.CONFLICT, "유저의 앨범 사진 개수 감소에 실패했습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/cheeeese/user/infrastructure/persistence/UserRepository.java
+++ b/src/main/java/com/cheeeese/user/infrastructure/persistence/UserRepository.java
@@ -2,9 +2,20 @@ package com.cheeeese.user.infrastructure.persistence;
 
 import com.cheeeese.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByProviderId(String providerId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE User u SET u.photoCnt = u.photoCnt + :count WHERE u.id = :userId")
+    int incrementPhotoCount(@Param("userId") Long userId, @Param("count") int count);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE User u SET u.photoCnt = u.photoCnt - :count WHERE u.id = :userId")
+    int decrementPhotoCount(@Param("userId") Long userId, @Param("count") int count);
 }

--- a/src/main/java/com/cheeeese/user/infrastructure/persistence/UserRepository.java
+++ b/src/main/java/com/cheeeese/user/infrastructure/persistence/UserRepository.java
@@ -16,6 +16,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     int incrementPhotoCount(@Param("userId") Long userId, @Param("count") int count);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
-    @Query("UPDATE User u SET u.photoCnt = u.photoCnt - :count WHERE u.id = :userId")
+    @Query("UPDATE User u SET u.photoCnt = u.photoCnt - :count WHERE u.id = :userId AND u.photoCnt >= :count")
     int decrementPhotoCount(@Param("userId") Long userId, @Param("count") int count);
 }


### PR DESCRIPTION
## 🔗 연관된 이슈
- #42 

## 🚀 변경 유형
- [x] ✨ 기능 추가 (feature)
- [x] 🐛 버그 수정 (fix)
- [ ] 📝 문서 변경 (docs)
- [ ] ♻️ 리팩토링 (refactor)
- [ ] 🧪 테스트 추가 / 수정 (test)
- [ ] ⚙️ 설정 변경 (chore)

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 미구현되어있던 사용자의 photoCnt 증가, 감소 로직을 추가했습니다.
- PhotoStatus에서 PROCESSING 을 없앴습니다.
  - 썸네일 callback 관련 서비스도 수정했습니다.
- 따라서 성공에 대한 응답을 프론트에서 따로 받지 않고 (썸네일 생성 = 업로드 성공)이라고 간주합니다.

## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
- 파이팅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **개선사항**
  * 사진 업로드 실패 처리 로직 단순화 — 실패 전용 보고 흐름으로 정리됨.
  * 업로드 전 이미지 URL이 일관되게 생성되어 미리보기/링크 신뢰도 향상.
  * 업로드 실패 시 사용자·앨범의 사진 개수 동기화 개선으로 통계 정확성 향상.
  * 중복 보고 처리를 보완한 검증 로직으로 무결성 강화.
  * 상태 관리 범위 축소로 상태 전환 처리 간소화.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->