### PR TITLE
fix: 비로그인, 앨범 미참여 사용자도 앨범 리스트 조회 가능하도록 수정

### DIFF
--- a/src/main/java/com/cheeeese/album/application/AlbumService.java
+++ b/src/main/java/com/cheeeese/album/application/AlbumService.java
@@ -11,6 +11,7 @@ import com.cheeeese.album.exception.code.AlbumErrorCode;
 import com.cheeeese.album.infrastructure.mapper.AlbumMapper;
 import com.cheeeese.album.infrastructure.mapper.UserAlbumMapper;
 import com.cheeeese.album.infrastructure.persistence.AlbumRepository;
+import com.cheeeese.global.security.CustomUserDetails;
 import com.cheeeese.photo.application.PhotoService;
 import com.cheeeese.album.domain.UserAlbum;
 import com.cheeeese.album.infrastructure.persistence.UserAlbumRepository;
@@ -22,6 +23,8 @@ import com.cheeeese.user.infrastructure.persistence.UserRepository;
 import com.github.f4b6a3.uuid.UuidCreator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -139,7 +142,10 @@ public class AlbumService {
         );
     }
 
-    public AlbumParticipantResponse getAlbumParticipantList(User currentUser, String code) {
+    public AlbumParticipantResponse getAlbumParticipantList(Authentication authentication, String code) {
+
+        User currentUser = extractUser(authentication);
+
         Album album = albumValidator.validateAlbumCode(code);
 
         boolean isExpired = album.isExpired();
@@ -166,6 +172,17 @@ public class AlbumService {
                 myRole,
                 participantInfos
         );
+    }
+
+    private User extractUser(Authentication authentication) {
+        if (authentication == null || authentication instanceof AnonymousAuthenticationToken) {
+            return null;
+        }
+        Object principal = authentication.getPrincipal();
+        if (principal instanceof CustomUserDetails customUserDetails) {
+            return customUserDetails.getUser();
+        }
+        return null;
     }
 
     private int calculateRemainingUploadSlots(Album album) {

--- a/src/main/java/com/cheeeese/album/application/AlbumService.java
+++ b/src/main/java/com/cheeeese/album/application/AlbumService.java
@@ -144,16 +144,21 @@ public class AlbumService {
 
         boolean isExpired = album.isExpired();
 
-        // 참여 여부 검증
-        UserAlbum myUserAlbum = userAlbumRepository.findByUserIdAndAlbumId(currentUser.getId(), album.getId())
-                .orElseThrow(() -> new AlbumException(AlbumErrorCode.USER_NOT_PARTICIPANT));
+        Role myRole = null;
+        Long currentUserId = currentUser != null ? currentUser.getId() : null;
 
-        Role myRole = myUserAlbum.getRole();
+        if (currentUserId != null) {
+            Optional<UserAlbum> myUserAlbumOptional = userAlbumRepository.findByUserIdAndAlbumId(currentUserId, album.getId());
+
+            if (myUserAlbumOptional.isPresent()) {
+                myRole = myUserAlbumOptional.get().getRole();
+            }
+        }
 
         // 앨범의 전체 참여자 목록
         List<UserAlbum> userAlbums = userAlbumRepository.findAllByAlbumId(album.getId());
 
-        List<AlbumParticipantListResponse.ParticipantInfo> participantInfos = buildSortedParticipantInfos(userAlbums, currentUser);
+        List<AlbumParticipantListResponse.ParticipantInfo> participantInfos = buildSortedParticipantInfos(userAlbums, currentUserId);
 
         return UserAlbumMapper.toAlbumParticipantResponse(
                 album,
@@ -203,13 +208,13 @@ public class AlbumService {
 
     private List<AlbumParticipantListResponse.ParticipantInfo> buildSortedParticipantInfos(
             List<UserAlbum> userAlbums,
-            User currentUser
+            Long currentUserId
     ) {
         return userAlbums.stream()
                 .map(userAlbum -> {
                     User user = userAlbum.getUser();
                     Role role = userAlbum.getRole();
-                    boolean isMe = user.getId().equals(currentUser.getId());
+                    boolean isMe = currentUserId != null && user.getId().equals(currentUserId);
                     return UserAlbumMapper.toParticipantInfo(user, role, isMe);
                 })
                 .sorted(Comparator

--- a/src/main/java/com/cheeeese/album/presentation/AlbumController.java
+++ b/src/main/java/com/cheeeese/album/presentation/AlbumController.java
@@ -5,10 +5,14 @@ import com.cheeeese.album.dto.request.AlbumCreationRequest;
 import com.cheeeese.album.dto.response.*;
 import com.cheeeese.album.presentation.swagger.AlbumSwagger;
 import com.cheeeese.global.common.CommonResponse;
+import com.cheeeese.global.security.CustomUserDetails;
 import com.cheeeese.global.util.CurrentUser;
 import com.cheeeese.user.domain.User;
+import com.cheeeese.user.infrastructure.persistence.UserRepository;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import static com.cheeeese.global.common.code.SuccessCode.*;
@@ -19,6 +23,7 @@ import static com.cheeeese.global.common.code.SuccessCode.*;
 public class AlbumController implements AlbumSwagger {
 
     private final AlbumService albumService;
+    private final UserRepository userRepository;
 
     @Override
     @PostMapping
@@ -60,12 +65,22 @@ public class AlbumController implements AlbumSwagger {
     @Override
     @GetMapping("/{code}/participants")
     public CommonResponse<AlbumParticipantResponse> getAlbumParticipants(
-            @CurrentUser User user,
+            Authentication authentication,
             @PathVariable String code
     ) {
+        User currentUser = null;
+
+        if (authentication != null && !(authentication instanceof AnonymousAuthenticationToken)) {
+            Object principal = authentication.getPrincipal();
+
+            if (principal instanceof CustomUserDetails customUserDetails) {
+                currentUser = customUserDetails.getUser();
+            }
+        }
+
       return CommonResponse.success(
               ALBUM_PARTICIPANT_FETCH_SUCCESS,
-              albumService.getAlbumParticipantList(user,code)
+              albumService.getAlbumParticipantList(currentUser,code)
       );
     }
 

--- a/src/main/java/com/cheeeese/album/presentation/AlbumController.java
+++ b/src/main/java/com/cheeeese/album/presentation/AlbumController.java
@@ -5,13 +5,10 @@ import com.cheeeese.album.dto.request.AlbumCreationRequest;
 import com.cheeeese.album.dto.response.*;
 import com.cheeeese.album.presentation.swagger.AlbumSwagger;
 import com.cheeeese.global.common.CommonResponse;
-import com.cheeeese.global.security.CustomUserDetails;
 import com.cheeeese.global.util.CurrentUser;
 import com.cheeeese.user.domain.User;
-import com.cheeeese.user.infrastructure.persistence.UserRepository;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
@@ -23,7 +20,6 @@ import static com.cheeeese.global.common.code.SuccessCode.*;
 public class AlbumController implements AlbumSwagger {
 
     private final AlbumService albumService;
-    private final UserRepository userRepository;
 
     @Override
     @PostMapping
@@ -68,19 +64,9 @@ public class AlbumController implements AlbumSwagger {
             Authentication authentication,
             @PathVariable String code
     ) {
-        User currentUser = null;
-
-        if (authentication != null && !(authentication instanceof AnonymousAuthenticationToken)) {
-            Object principal = authentication.getPrincipal();
-
-            if (principal instanceof CustomUserDetails customUserDetails) {
-                currentUser = customUserDetails.getUser();
-            }
-        }
-
       return CommonResponse.success(
               ALBUM_PARTICIPANT_FETCH_SUCCESS,
-              albumService.getAlbumParticipantList(currentUser,code)
+              albumService.getAlbumParticipantList(authentication, code)
       );
     }
 

--- a/src/main/java/com/cheeeese/album/presentation/swagger/AlbumSwagger.java
+++ b/src/main/java/com/cheeeese/album/presentation/swagger/AlbumSwagger.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -250,7 +251,7 @@ public interface AlbumSwagger {
             )
     })
     CommonResponse<AlbumParticipantResponse> getAlbumParticipants(
-            @CurrentUser User user,
+            Authentication authentication,
             @PathVariable String code
     );
 }

--- a/src/main/java/com/cheeeese/global/config/SecurityConfig.java
+++ b/src/main/java/com/cheeeese/global/config/SecurityConfig.java
@@ -37,6 +37,7 @@ public class SecurityConfig {
             "/v1/auth/exchange",
             "/v1/auth/reissue",
             "/v1/album/*/invitation",
+            "/v1/album/*/participants",
             "/internal/thumbnail/complete"
     };
 


### PR DESCRIPTION
## 🔗 연관된 이슈
- #48 

## 🚀 변경 유형
- [ ] ✨ 기능 추가 (feature)
- [x] 🐛 버그 수정 (fix)
- [ ] 📝 문서 변경 (docs)
- [ ] ♻️ 리팩토링 (refactor)
- [ ] 🧪 테스트 추가 / 수정 (test)
- [ ] ⚙️ 설정 변경 (chore)

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 비로그인 사용자
- 로그인 사용자이지만 앨범 미참여 사용자
=> 앨범 참여자 리스트 조회 가능하도록 수정

## 📸 스크린샷
> 비로그인/앨범 미참여자의 경우 myRole = null 로 표시
<img width="463" height="553" alt="스크린샷 2025-11-07 오후 1 23 22" src="https://github.com/user-attachments/assets/5fc67fa7-7036-4882-b58f-0829982358c5" />

<br>
<br>

> 로그인 앨범 참여자의 경우 myRole이 GUEST, MAKER 로 표시됨
<img width="471" height="559" alt="스크린샷 2025-11-07 오후 1 30 45" src="https://github.com/user-attachments/assets/d9c4f717-1186-412d-a955-f6b61a55f93d" />

## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->
- 치즈네컷 구현하다가 놓친 부분 있어서 수정했습니다~

### 📜 리뷰 규칙

Reviewer는 아래 **P5 Rule**을 참고하여 리뷰를 진행합니다.
P5 Rule을 통해 Reviewer는 Reviewee에게 리뷰의 의도를 보다 정확히 전달할 수 있습니다.

> - **P1:** 꼭 반영해주세요 (Comment)
> - **P2:** 적극적으로 고려해주세요 (Comment)
> - **P3:** 웬만하면 반영해 주세요 (Comment)
> - **P4:** 반영해도 좋고 넘어가도 좋습니다 (Approve)
> - **P5:** 그냥 사소한 의견입니다 (Approve)

- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 앨범 참가자 조회 엔드포인트가 공개되어 인증 없이도 접근할 수 있습니다.

* **버그 수정**
  * 인증이 없는 경우에도 참가자 목록을 안전하게 반환하도록 안정성이 향상되었습니다.
  * 인증된 사용자의 경우 본인 표시 및 역할 정보가 올바르게 반영되도록 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->