### PR TITLE
feat: cheese4cutPhoto 엔티티 추가 및 스케줄러 기능 구현 변경

### DIFF
--- a/src/main/java/com/cheeeese/album/application/AlbumExpirationScheduler.java
+++ b/src/main/java/com/cheeeese/album/application/AlbumExpirationScheduler.java
@@ -16,19 +16,15 @@ public class AlbumExpirationScheduler {
     private final AlbumExpirationRedisRepository albumExpirationRedisRepository;
     private final AlbumExpirationService albumExpirationService;
 
-    @Scheduled(fixedDelay = 1000L)
+    @Scheduled(fixedDelay = 10000L)
     public void handleAlbumExpirations() {
-        Set<Long> trackedAlbumIds = albumExpirationRedisRepository.getTrackedAlbumIds();
+        Set<Long> expiredAlbumIds = albumExpirationRedisRepository.getExpiredAlbumIds();
 
-        if (trackedAlbumIds.isEmpty()) {
+        if (expiredAlbumIds.isEmpty()) {
             return;
         }
 
-        for (Long albumId : trackedAlbumIds) {
-            if (!albumExpirationRedisRepository.isExpired(albumId)) {
-                continue;
-            }
-
+        for (Long albumId : expiredAlbumIds) {
             try {
                 albumExpirationService.expireAlbum(albumId);
                 albumExpirationRedisRepository.unregister(albumId);

--- a/src/main/java/com/cheeeese/album/application/AlbumExpirationService.java
+++ b/src/main/java/com/cheeeese/album/application/AlbumExpirationService.java
@@ -4,9 +4,9 @@ import com.cheeeese.album.domain.Album;
 import com.cheeeese.album.exception.AlbumException;
 import com.cheeeese.album.exception.code.AlbumErrorCode;
 import com.cheeeese.album.infrastructure.persistence.AlbumRepository;
-import com.cheeeese.cheese4cut.domain.Cheese4cut;
 import com.cheeeese.cheese4cut.infrastructure.mapper.Cheese4cutMapper;
 import com.cheeeese.cheese4cut.infrastructure.persistence.Cheese4cutRepository;
+import com.cheeeese.photo.domain.Photo;
 import com.cheeeese.photo.domain.PhotoStatus;
 import com.cheeeese.photo.infrastructure.persistence.PhotoRepository;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +16,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -23,7 +27,6 @@ import java.util.List;
 public class AlbumExpirationService {
 
     private static final int CHEESE4CUT_PHOTO_COUNT = 4;
-    // TODO: 최종 프레임 백엔드에서 저장안함에 따라 photo 4장만 저장
 
     private final AlbumRepository albumRepository;
     private final PhotoRepository photoRepository;
@@ -58,9 +61,21 @@ public class AlbumExpirationService {
             return;
         }
 
-        Cheese4cut cheese4cut = Cheese4cutMapper.toEntity(album, topPhotoIds);
+        List<Photo> photos = photoRepository.findAllByIdIn(topPhotoIds);
+        Map<Long, Photo> photoMap = photos.stream()
+                .collect(Collectors.toMap(Photo::getId, Function.identity()));
 
-        cheese4cutRepository.save(cheese4cut);
+        List<Photo> orderedPhotos = topPhotoIds.stream()
+                .map(photoMap::get)
+                .collect(Collectors.toList());
+
+        if (orderedPhotos.stream().anyMatch(Objects::isNull)) {
+            log.warn("[AlbumExpiration] Album id={} has missing photos for cheese4cut creation", albumId);
+            return;
+        }
+
+        cheese4cutRepository.save(Cheese4cutMapper.toEntity(album, orderedPhotos));
+
         log.info("[AlbumExpiration] Cheese4cut created automatically for album id={}", albumId);
     }
 }

--- a/src/main/java/com/cheeeese/album/application/AlbumExpirationService.java
+++ b/src/main/java/com/cheeeese/album/application/AlbumExpirationService.java
@@ -38,7 +38,7 @@ public class AlbumExpirationService {
                 .orElseThrow(() -> new AlbumException(AlbumErrorCode.ALBUM_NOT_FOUND));
 
         if (album.getStatus() != Album.AlbumStatus.EXPIRED) {
-            album.expire();
+            albumRepository.updateStatus(albumId, Album.AlbumStatus.EXPIRED);
             log.info("[AlbumExpiration] Album id={} status updated to EXPIRED", albumId);
         }
 

--- a/src/main/java/com/cheeeese/album/application/AlbumService.java
+++ b/src/main/java/com/cheeeese/album/application/AlbumService.java
@@ -10,8 +10,8 @@ import com.cheeeese.album.exception.AlbumException;
 import com.cheeeese.album.exception.code.AlbumErrorCode;
 import com.cheeeese.album.infrastructure.mapper.AlbumMapper;
 import com.cheeeese.album.infrastructure.mapper.UserAlbumMapper;
-import com.cheeeese.album.infrastructure.persistence.AlbumRepository;
 import com.cheeeese.album.infrastructure.persistence.AlbumExpirationRedisRepository;
+import com.cheeeese.album.infrastructure.persistence.AlbumRepository;
 import com.cheeeese.global.security.CustomUserDetails;
 import com.cheeeese.photo.application.PhotoService;
 import com.cheeeese.album.domain.UserAlbum;
@@ -59,6 +59,8 @@ public class AlbumService {
 
         albumValidator.validateAlbumCreation(request);
 
+        LocalDateTime expiredAt = LocalDateTime.now().plusDays(7);
+
         Album album = AlbumMapper.toEntity(
                 user.getId(),
                 request.title(),
@@ -67,7 +69,7 @@ public class AlbumService {
                 request.participant(),
                 request.eventDate(),
                 true,
-                LocalDateTime.now().plusDays(7)
+                expiredAt
         );
         albumRepository.save(album);
 
@@ -77,7 +79,7 @@ public class AlbumService {
                 Role.MAKER
         ));
 
-        albumExpirationRedisRepository.registerAlbum(album.getId());
+        albumExpirationRedisRepository.registerAlbum(album.getId(), expiredAt);
 
         return AlbumMapper.toCreationResponse(album);
     }

--- a/src/main/java/com/cheeeese/album/domain/Album.java
+++ b/src/main/java/com/cheeeese/album/domain/Album.java
@@ -66,10 +66,6 @@ public class Album extends BaseEntity {
         return this.expiredAt.isBefore(LocalDateTime.now()) || this.status == AlbumStatus.EXPIRED;
     }
 
-    public void expire() {
-        this.status = AlbumStatus.EXPIRED;
-    }
-
     @Builder
     private Album(
             Long makerId,

--- a/src/main/java/com/cheeeese/album/infrastructure/persistence/AlbumExpirationRedisRepository.java
+++ b/src/main/java/com/cheeeese/album/infrastructure/persistence/AlbumExpirationRedisRepository.java
@@ -5,61 +5,62 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
-import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.Collections;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 @Component
 @RequiredArgsConstructor
 public class AlbumExpirationRedisRepository {
 
-    private static final String TRACKING_KEY = "expired:album:tracking";
-    private static final Duration ALBUM_TTL = Duration.ofDays(7);
+    private static final String EXPIRATION_ZSET_KEY = "expired:album:zset";
+    private static final ZoneOffset KST_ZONE = ZoneOffset.of("+09:00");
 
     @Qualifier("cacheRedisTemplate")
     private final RedisTemplate<String, Object> cacheRedisTemplate;
 
-    public void registerAlbum(Long albumId) {
-        String key = buildAlbumKey(albumId);
-        cacheRedisTemplate.opsForValue().set(key, albumId.toString(), ALBUM_TTL);
-        cacheRedisTemplate.opsForSet().add(TRACKING_KEY, albumId.toString());
+    /**
+     * ZSET에 앨범 ID와 만료 시간을 Score로 등록
+     * Score는 Unix Timestamp(밀리초)로 사용
+     * @param albumId 앨범 고유 ID
+     * @param expiredAt 앨범 만료 시각 (LocalDateTime)
+     */
+    public void registerAlbum(Long albumId, LocalDateTime expiredAt) {
+        // LocalDateTime을 Unix Timestamp (ms)로 변환
+        long expirationMillis = expiredAt.toInstant(KST_ZONE).toEpochMilli();
+
+        // ZADD key score member
+        cacheRedisTemplate.opsForZSet().add(EXPIRATION_ZSET_KEY, albumId.toString(), (double) expirationMillis);
     }
 
-    public Set<Long> getTrackedAlbumIds() {
-        Set<Object> members = cacheRedisTemplate.opsForSet().members(TRACKING_KEY);
+    /**
+     * 현재 시각을 기준으로 만료된 앨범 ID 목록만 ZSET에서 조회 (O(log N + k))
+     * @return 만료된 앨범 ID Set
+     */
+    public Set<Long> getExpiredAlbumIds() {
+        // 현재 시각의 Unix Timestamp (밀리초)
+        long currentTimestamp = LocalDateTime.now().toInstant(KST_ZONE).toEpochMilli();
+
+        // ZRANGEBYSCORE key min max: Score가 0부터 현재 시각까지인 모든 Member를 조회
+        Set<Object> members = cacheRedisTemplate.opsForZSet().rangeByScore(EXPIRATION_ZSET_KEY, 0, currentTimestamp);
+
         if (members == null || members.isEmpty()) {
             return Collections.emptySet();
         }
+
         return members.stream()
                 .map(Object::toString)
                 .map(Long::valueOf)
                 .collect(Collectors.toSet());
     }
 
-    public boolean isExpired(Long albumId) {
-        Long ttl = cacheRedisTemplate.getExpire(buildAlbumKey(albumId), TimeUnit.SECONDS);
-        if (ttl == null) {
-            return true;
-        }
-
-        if (ttl == -2) {
-            return true;
-        }
-
-        if (ttl == -1) {
-            return false;
-        }
-
-        return ttl <= 0;
-    }
-
+    /**
+     * ZSET에서 만료 처리된 앨범을 제거 (O(log N))
+     * @param albumId 앨범 고유 ID
+     */
     public void unregister(Long albumId) {
-        cacheRedisTemplate.opsForSet().remove(TRACKING_KEY, albumId.toString());
-    }
-
-    private String buildAlbumKey(Long albumId) {
-        return "expired:album:" + albumId;
+        cacheRedisTemplate.opsForZSet().remove(EXPIRATION_ZSET_KEY, albumId.toString());
     }
 }

--- a/src/main/java/com/cheeeese/album/infrastructure/persistence/AlbumRepository.java
+++ b/src/main/java/com/cheeeese/album/infrastructure/persistence/AlbumRepository.java
@@ -38,4 +38,9 @@ public interface AlbumRepository extends JpaRepository<Album, Long> {
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE Album a SET a.currentPhotoCount = a.currentPhotoCount - :count WHERE a.id = :albumId AND a.currentPhotoCount >= :count")
     int decrementPhotoCount(@Param("albumId") Long albumId, @Param("count") int count);
+
+    @Modifying
+    @Query("UPDATE Album a SET a.status = :status WHERE a.id = :id AND a.status <> :status")
+    void updateStatus(Long id, Album.AlbumStatus status);
+
 }

--- a/src/main/java/com/cheeeese/cheese4cut/application/Cheese4cutService.java
+++ b/src/main/java/com/cheeeese/cheese4cut/application/Cheese4cutService.java
@@ -8,12 +8,15 @@ import com.cheeeese.album.infrastructure.persistence.AlbumRepository;
 import com.cheeeese.cheese4cut.application.validator.Cheese4cutValidator;
 import com.cheeeese.cheese4cut.domain.Cheese4cut;
 import com.cheeeese.cheese4cut.dto.request.Cheese4cutFixedRequest;
+import com.cheeeese.cheese4cut.dto.response.Cheese4cutFinalResponse;
 import com.cheeeese.cheese4cut.dto.response.Cheese4cutPresignedUrlResponse;
+import com.cheeeese.cheese4cut.dto.response.Cheese4cutPreviewResponse;
 import com.cheeeese.cheese4cut.dto.response.Cheese4cutResponse;
 import com.cheeeese.cheese4cut.exception.Cheese4cutException;
 import com.cheeeese.cheese4cut.exception.code.Cheese4cutErrorCode;
 import com.cheeeese.cheese4cut.infrastructure.mapper.Cheese4cutMapper;
 import com.cheeeese.cheese4cut.infrastructure.persistence.Cheese4cutRepository;
+import com.cheeeese.global.util.resolver.CdnUrlResolver;
 import com.cheeeese.photo.application.PresignedUrlService;
 import com.cheeeese.photo.domain.Photo;
 import com.cheeeese.photo.domain.PhotoStatus;
@@ -30,6 +33,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 @Service
 @RequiredArgsConstructor
@@ -43,6 +47,7 @@ public class Cheese4cutService {
     private final AlbumValidator albumValidator;
     private final PresignedUrlService presignedUrlService;
     private final Cheese4cutValidator cheese4cutValidator;
+    private final CdnUrlResolver cdnUrlResolver;
 
     @Transactional(readOnly = true)
     public Cheese4cutResponse getCheese4cutByAlbumCode(String code) {
@@ -52,7 +57,17 @@ public class Cheese4cutService {
         Optional<Cheese4cut> cheese4cutOptional = cheese4cutRepository.findByAlbumId(album.getId());
 
         if (cheese4cutOptional.isPresent()) {
-            return Cheese4cutMapper.toFinalResponse(cheese4cutOptional.get());
+            Cheese4cut cheese4cut = cheese4cutOptional.get();
+
+            List<Cheese4cutFinalResponse.FinalPhotoInfo> photos = cheese4cut.getPhotos().stream()
+                    .map(p -> Cheese4cutMapper.toFinalPhotoInfo(
+                            p.getPhotoId(),
+                            cdnUrlResolver.resolveOriginal(p.getImageUrl()),
+                            p.getPhotoRank()
+                    ))
+                    .toList();
+
+            return Cheese4cutMapper.toFinalResponse(photos);
         }
 
         return getPreviewResponse(album.getId(), album.getParticipant());
@@ -73,7 +88,17 @@ public class Cheese4cutService {
 
         long uniqueLikesCount = photoLikesRepository.countDistinctUserIdsByPhotoIds(topPhotoIds);
 
-        return Cheese4cutMapper.toPreviewResponse(orderedPhotos, uniqueLikesCount, participant);
+        List<Cheese4cutPreviewResponse.PreviewPhotoInfo> resolvedPhotoInfos =
+                IntStream.range(0, orderedPhotos.size())
+                        .mapToObj(index -> {
+                            Photo p = orderedPhotos.get(index);
+                            return Cheese4cutMapper.toPreviewPhotoInfo(
+                                    p.getId(), cdnUrlResolver.resolveOriginal(p.getImageUrl()), index+1
+                            );
+                        })
+                        .toList();
+
+        return Cheese4cutMapper.toPreviewResponse(resolvedPhotoInfos, uniqueLikesCount, participant);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/cheeeese/cheese4cut/application/Cheese4cutService.java
+++ b/src/main/java/com/cheeeese/cheese4cut/application/Cheese4cutService.java
@@ -51,9 +51,8 @@ public class Cheese4cutService {
 
         Optional<Cheese4cut> cheese4cutOptional = cheese4cutRepository.findByAlbumId(album.getId());
 
-        // TODO: 최종 확정된 4장의 photo 제공으로 변경
         if (cheese4cutOptional.isPresent()) {
-            return Cheese4cutMapper.toFinalResponse();
+            return Cheese4cutMapper.toFinalResponse(cheese4cutOptional.get());
         }
 
         return getPreviewResponse(album.getId(), album.getParticipant());
@@ -70,20 +69,7 @@ public class Cheese4cutService {
             throw new Cheese4cutException(Cheese4cutErrorCode.INSUFFICIENT_COUNT_FOR_CHEESE4CUT);
         }
 
-        List<Photo> topPhotos = photoRepository.findAllById(topPhotoIds);
-
-        Map<Long, Photo> photoMap = topPhotos.stream()
-                .collect(Collectors.toMap(Photo::getId, Function.identity()));
-
-        List<Photo> orderedPhotos = topPhotoIds.stream()
-                .map(photoId -> {
-                    Photo photo = photoMap.get(photoId);
-                    if (photo == null) {
-                        throw new Cheese4cutException(Cheese4cutErrorCode.INSUFFICIENT_COUNT_FOR_CHEESE4CUT);
-                    }
-                    return photo;
-                })
-                .toList();
+        List<Photo> orderedPhotos = getOrderedPhotos(topPhotoIds);
 
         long uniqueLikesCount = photoLikesRepository.countDistinctUserIdsByPhotoIds(topPhotoIds);
 
@@ -115,8 +101,34 @@ public class Cheese4cutService {
 
         cheese4cutValidator.validateFinalizePhotos(album, request.photoIds());
 
-        Cheese4cut cheese4cut = Cheese4cutMapper.toEntity(album, request);
+        List<Photo> orderedPhotos =
+                photoRepository.findAllByIdInOrderByLikesDescCreatedDesc(request.photoIds());
 
-        cheese4cutRepository.save(cheese4cut);
+        if (orderedPhotos.size() != request.photoIds().size())
+            throw new Cheese4cutException(Cheese4cutErrorCode.INSUFFICIENT_COUNT_FOR_CHEESE4CUT);
+
+        cheese4cutRepository.save(Cheese4cutMapper.toEntity(album, orderedPhotos));
+    }
+
+    private List<Photo> getOrderedPhotos(List<Long> photoIds) {
+        List<Photo> photos = photoRepository.findAllByIdIn(photoIds);
+
+        Map<Long, Photo> photoMap = photos.stream()
+                .collect(Collectors.toMap(Photo::getId, Function.identity()));
+
+        List<Photo> orderedPhotos = photoIds.stream()
+                .map(photoId -> {
+                    Photo photo = photoMap.get(photoId);
+                    if (photo == null) {
+                        throw new Cheese4cutException(Cheese4cutErrorCode.INSUFFICIENT_COUNT_FOR_CHEESE4CUT);
+                    }
+                    return photo;
+                })
+                .toList();
+
+        if (orderedPhotos.size() != photoIds.size()) {
+            throw new Cheese4cutException(Cheese4cutErrorCode.INSUFFICIENT_COUNT_FOR_CHEESE4CUT);
+        }
+        return orderedPhotos;
     }
 }

--- a/src/main/java/com/cheeeese/cheese4cut/application/Cheese4cutService.java
+++ b/src/main/java/com/cheeeese/cheese4cut/application/Cheese4cutService.java
@@ -2,9 +2,12 @@ package com.cheeeese.cheese4cut.application;
 
 import com.cheeeese.album.application.validator.AlbumValidator;
 import com.cheeeese.album.domain.Album;
+import com.cheeeese.album.domain.UserAlbum;
+import com.cheeeese.album.domain.type.Role;
 import com.cheeeese.album.exception.AlbumException;
 import com.cheeeese.album.exception.code.AlbumErrorCode;
 import com.cheeeese.album.infrastructure.persistence.AlbumRepository;
+import com.cheeeese.album.infrastructure.persistence.UserAlbumRepository;
 import com.cheeeese.cheese4cut.application.validator.Cheese4cutValidator;
 import com.cheeeese.cheese4cut.domain.Cheese4cut;
 import com.cheeeese.cheese4cut.dto.request.Cheese4cutFixedRequest;
@@ -16,6 +19,7 @@ import com.cheeeese.cheese4cut.exception.Cheese4cutException;
 import com.cheeeese.cheese4cut.exception.code.Cheese4cutErrorCode;
 import com.cheeeese.cheese4cut.infrastructure.mapper.Cheese4cutMapper;
 import com.cheeeese.cheese4cut.infrastructure.persistence.Cheese4cutRepository;
+import com.cheeeese.global.security.CustomUserDetails;
 import com.cheeeese.global.util.resolver.CdnUrlResolver;
 import com.cheeeese.photo.application.PresignedUrlService;
 import com.cheeeese.photo.domain.Photo;
@@ -25,6 +29,8 @@ import com.cheeeese.photo.infrastructure.persistence.PhotoRepository;
 import com.cheeeese.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -44,13 +50,14 @@ public class Cheese4cutService {
     private final AlbumRepository albumRepository;
     private final PhotoRepository photoRepository;
     private final PhotoLikesRepository photoLikesRepository;
+    private final UserAlbumRepository userAlbumRepository;
     private final AlbumValidator albumValidator;
     private final PresignedUrlService presignedUrlService;
     private final Cheese4cutValidator cheese4cutValidator;
     private final CdnUrlResolver cdnUrlResolver;
 
     @Transactional(readOnly = true)
-    public Cheese4cutResponse getCheese4cutByAlbumCode(String code) {
+    public Cheese4cutResponse getCheese4cutByAlbumCode(Authentication authentication, String code) {
         Album album = albumRepository.findByCode(code)
                 .orElseThrow(() -> new AlbumException(AlbumErrorCode.ALBUM_NOT_FOUND));
 
@@ -70,10 +77,23 @@ public class Cheese4cutService {
             return Cheese4cutMapper.toFinalResponse(photos);
         }
 
-        return getPreviewResponse(album.getId(), album.getParticipant());
+        User currentUser = extractUser(authentication);
+
+        Role myRole = null;
+        Long currentUserId = currentUser != null ? currentUser.getId() : null;
+
+        if (currentUserId != null) {
+            Optional<UserAlbum> myUserAlbumOptional = userAlbumRepository.findByUserIdAndAlbumId(currentUserId, album.getId());
+
+            if (myUserAlbumOptional.isPresent()) {
+                myRole = myUserAlbumOptional.get().getRole();
+            }
+        }
+
+        return getPreviewResponse(album.getId(), album.getParticipant(), myRole);
     }
 
-    private Cheese4cutResponse getPreviewResponse(Long albumId, int participant) {
+    private Cheese4cutResponse getPreviewResponse(Long albumId, int participant, Role myRole) {
         List<Long> topPhotoIds = photoRepository.findTop4CompletedPhotoIdsByLikes(
                 albumId,
                 PhotoStatus.COMPLETED,
@@ -98,7 +118,7 @@ public class Cheese4cutService {
                         })
                         .toList();
 
-        return Cheese4cutMapper.toPreviewResponse(resolvedPhotoInfos, uniqueLikesCount, participant);
+        return Cheese4cutMapper.toPreviewResponse(resolvedPhotoInfos, uniqueLikesCount, participant, myRole);
     }
 
     @Transactional(readOnly = true)
@@ -155,5 +175,16 @@ public class Cheese4cutService {
             throw new Cheese4cutException(Cheese4cutErrorCode.INSUFFICIENT_COUNT_FOR_CHEESE4CUT);
         }
         return orderedPhotos;
+    }
+
+    private User extractUser(Authentication authentication) {
+        if (authentication == null || authentication instanceof AnonymousAuthenticationToken) {
+            return null;
+        }
+        Object principal = authentication.getPrincipal();
+        if (principal instanceof CustomUserDetails customUserDetails) {
+            return customUserDetails.getUser();
+        }
+        return null;
     }
 }

--- a/src/main/java/com/cheeeese/cheese4cut/domain/Cheese4cut.java
+++ b/src/main/java/com/cheeeese/cheese4cut/domain/Cheese4cut.java
@@ -3,12 +3,12 @@ package com.cheeeese.cheese4cut.domain;
 import com.cheeeese.album.domain.Album;
 import com.cheeeese.global.domain.BaseEntity;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -26,17 +26,22 @@ public class Cheese4cut extends BaseEntity {
     @JoinColumn(name = "album_id", nullable = false, unique = true)
     private Album album;
 
-    @ElementCollection
-    @CollectionTable(name = "cheese4cut_photos", joinColumns = @JoinColumn(name = "cheese4cut_id"))
-    @Column(name = "photo_id", nullable = false)
-    @Size(min = 4, max = 4)
-    private List<Long> photoIds;
+    @OneToMany(mappedBy = "cheese4cut", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("photoRank ASC")
+    private List<Cheese4cutPhoto> photos = new ArrayList<>();
 
 
     @Builder
-    private Cheese4cut(Album album, List<Long> photoIds) {
+    private Cheese4cut(Album album, List<Cheese4cutPhoto> photos) {
         this.album = album;
-        this.photoIds = photoIds;
+        if (photos != null) {
+            photos.forEach(this::addPhoto);
+        }
+    }
+
+    private void addPhoto(Cheese4cutPhoto photo) {
+        photo.assignToCheese4cut(this);
+        this.photos.add(photo);
     }
 }
 

--- a/src/main/java/com/cheeeese/cheese4cut/domain/Cheese4cutPhoto.java
+++ b/src/main/java/com/cheeeese/cheese4cut/domain/Cheese4cutPhoto.java
@@ -1,0 +1,48 @@
+package com.cheeeese.cheese4cut.domain;
+
+import com.cheeeese.global.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "cheese4cut_photo")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Cheese4cutPhoto extends BaseEntity {
+
+    @Id
+    @Column(name = "cheese4cut_photo_id", nullable = false)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "cheese4cut_id", nullable = false)
+    private Cheese4cut cheese4cut;
+
+    @Column(name = "photo_id", nullable = false)
+    private Long photoId;
+
+    @Column(name = "image_url", columnDefinition = "TEXT", nullable = false)
+    private String imageUrl;
+
+    @Column(name = "thumbnail_image_url", columnDefinition = "TEXT")
+    private String thumbnailImageUrl;
+
+    @Column(name = "photo_rank", nullable = false)
+    private int photoRank;
+
+    @Builder
+    private Cheese4cutPhoto(Long photoId, String imageUrl, String thumbnailImageUrl, int photoRank) {
+        this.photoId = photoId;
+        this.imageUrl = imageUrl;
+        this.thumbnailImageUrl = thumbnailImageUrl;
+        this.photoRank = photoRank;
+    }
+
+    void assignToCheese4cut(Cheese4cut cheese4cut) {
+        this.cheese4cut = cheese4cut;
+    }
+}

--- a/src/main/java/com/cheeeese/cheese4cut/dto/response/Cheese4cutFinalResponse.java
+++ b/src/main/java/com/cheeeese/cheese4cut/dto/response/Cheese4cutFinalResponse.java
@@ -24,9 +24,6 @@ public record Cheese4cutFinalResponse(
                 @Schema(description = "사진 원본 URL", example = "https://cdn.cheeeese.com/album/1/original/101.jpg")
                 String imageUrl,
 
-                @Schema(description = "사진 썸네일 URL", example = "https://cdn.cheeeese.com/album/1/thumbnail/101.jpg")
-                String thumbnailImageUrl,
-
                 @Schema(description = "선정 순위 (1~4)", example = "1")
                 int photoRank
         ) {}

--- a/src/main/java/com/cheeeese/cheese4cut/dto/response/Cheese4cutFinalResponse.java
+++ b/src/main/java/com/cheeeese/cheese4cut/dto/response/Cheese4cutFinalResponse.java
@@ -3,10 +3,31 @@ package com.cheeeese.cheese4cut.dto.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
+import java.util.List;
+
 @Builder
-@Schema(description = "치즈네컷 확정 완료 응답 DTO (최종 프레임 이미지)")
+@Schema(description = "치즈네컷 확정 완료 응답 DTO (선정된 사진 4장)")
 public record Cheese4cutFinalResponse(
         @Schema(description = "확정 여부 (항상 true)", example = "true")
-        boolean isFinalized
+        boolean isFinalized,
+
+        @Schema(description = "확정된 사진 정보 목록 (정확히 4개)")
+        List<FinalPhotoInfo> photos
 ) implements Cheese4cutResponse {
+
+        @Builder
+        @Schema(description = "확정된 사진 정보")
+        public record FinalPhotoInfo(
+                @Schema(description = "원본 사진 ID", example = "101")
+                Long photoId,
+
+                @Schema(description = "사진 원본 URL", example = "https://cdn.cheeeese.com/album/1/original/101.jpg")
+                String imageUrl,
+
+                @Schema(description = "사진 썸네일 URL", example = "https://cdn.cheeeese.com/album/1/thumbnail/101.jpg")
+                String thumbnailImageUrl,
+
+                @Schema(description = "선정 순위 (1~4)", example = "1")
+                int photoRank
+        ) {}
 }

--- a/src/main/java/com/cheeeese/cheese4cut/dto/response/Cheese4cutPreviewResponse.java
+++ b/src/main/java/com/cheeeese/cheese4cut/dto/response/Cheese4cutPreviewResponse.java
@@ -28,6 +28,9 @@ public record Cheese4cutPreviewResponse(
             Long photoId,
 
             @Schema(description = "사진 원본 URL", example = "https://cdn.cheeeese.com/album/1/original/101.jpg")
-            String imageUrl
+            String imageUrl,
+
+            @Schema(description = "선정 순위 (1~4)", example = "1")
+            int photoRank
     ) {}
 }

--- a/src/main/java/com/cheeeese/cheese4cut/dto/response/Cheese4cutPreviewResponse.java
+++ b/src/main/java/com/cheeeese/cheese4cut/dto/response/Cheese4cutPreviewResponse.java
@@ -1,5 +1,6 @@
 package com.cheeeese.cheese4cut.dto.response;
 
+import com.cheeeese.album.domain.type.Role;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
@@ -18,7 +19,10 @@ public record Cheese4cutPreviewResponse(
         int uniqueLikesCount,
 
         @Schema(description = "전체 참여자 수", example = "6")
-        int participant
+        int participant,
+
+        @Schema(description = "사용자 역할", example = "MAKER")
+        Role myRole
 
 ) implements Cheese4cutResponse {
     @Builder

--- a/src/main/java/com/cheeeese/cheese4cut/infrastructure/mapper/Cheese4cutMapper.java
+++ b/src/main/java/com/cheeeese/cheese4cut/infrastructure/mapper/Cheese4cutMapper.java
@@ -1,6 +1,7 @@
 package com.cheeeese.cheese4cut.infrastructure.mapper;
 
 import com.cheeeese.album.domain.Album;
+import com.cheeeese.album.domain.type.Role;
 import com.cheeeese.cheese4cut.domain.Cheese4cut;
 import com.cheeeese.cheese4cut.domain.Cheese4cutPhoto;
 import com.cheeeese.cheese4cut.dto.response.Cheese4cutFinalResponse;
@@ -32,13 +33,15 @@ public class Cheese4cutMapper {
     public static Cheese4cutPreviewResponse toPreviewResponse(
             List<Cheese4cutPreviewResponse.PreviewPhotoInfo> photoInfos,
             long uniqueLikesCount,
-            int participant
+            int participant,
+            Role myRole
     ) {
         return Cheese4cutPreviewResponse.builder()
                 .isFinalized(false)
                 .previewPhotos(photoInfos)
                 .uniqueLikesCount((int) uniqueLikesCount)
                 .participant(participant)
+                .myRole(myRole)
                 .build();
     }
 

--- a/src/main/java/com/cheeeese/cheese4cut/infrastructure/mapper/Cheese4cutMapper.java
+++ b/src/main/java/com/cheeeese/cheese4cut/infrastructure/mapper/Cheese4cutMapper.java
@@ -19,17 +19,10 @@ public class Cheese4cutMapper {
     /**
      * 확정 후 응답 (Cheese4cut 엔티티 기반)
      */
-    public static Cheese4cutFinalResponse toFinalResponse(Cheese4cut cheese4cut) {
+    public static Cheese4cutFinalResponse toFinalResponse(List<Cheese4cutFinalResponse.FinalPhotoInfo> photos) {
         return Cheese4cutFinalResponse.builder()
                 .isFinalized(true)
-                .photos(cheese4cut.getPhotos().stream()
-                        .map(photo -> Cheese4cutFinalResponse.FinalPhotoInfo.builder()
-                                .photoId(photo.getPhotoId())
-                                .imageUrl(photo.getImageUrl())
-                                .thumbnailImageUrl(photo.getThumbnailImageUrl())
-                                .photoRank(photo.getPhotoRank())
-                                .build())
-                        .collect(Collectors.toList()))
+                .photos(photos)
                 .build();
     }
 
@@ -37,17 +30,10 @@ public class Cheese4cutMapper {
      * 확정 전 응답 (좋아요 TOP 4 사진 목록 기반)
      */
     public static Cheese4cutPreviewResponse toPreviewResponse(
-            List<Photo> topPhotos,
+            List<Cheese4cutPreviewResponse.PreviewPhotoInfo> photoInfos,
             long uniqueLikesCount,
             int participant
     ) {
-        List<Cheese4cutPreviewResponse.PreviewPhotoInfo> photoInfos = topPhotos.stream()
-                .map(photo -> Cheese4cutPreviewResponse.PreviewPhotoInfo.builder()
-                        .photoId(photo.getId())
-                        .imageUrl(photo.getImageUrl())
-                        .build())
-                .collect(Collectors.toList());
-
         return Cheese4cutPreviewResponse.builder()
                 .isFinalized(false)
                 .previewPhotos(photoInfos)
@@ -80,4 +66,24 @@ public class Cheese4cutMapper {
         return Cheese4cutPresignedUrlResponse.builder()
                 .uploadUrl(uploadUrl).build();
     }
+
+    public static Cheese4cutFinalResponse.FinalPhotoInfo toFinalPhotoInfo(
+            Long photoId, String imageUrl, int rank) {
+
+        return Cheese4cutFinalResponse.FinalPhotoInfo.builder()
+                .photoId(photoId)
+                .imageUrl(imageUrl)
+                .photoRank(rank)
+                .build();
+    }
+
+    public static Cheese4cutPreviewResponse.PreviewPhotoInfo toPreviewPhotoInfo(
+            Long photoId, String imageUrl, int rank) {
+        return Cheese4cutPreviewResponse.PreviewPhotoInfo.builder()
+                .photoId(photoId)
+                .imageUrl(imageUrl)
+                .photoRank(rank)
+                .build();
+    }
+
 }

--- a/src/main/java/com/cheeeese/cheese4cut/infrastructure/mapper/Cheese4cutMapper.java
+++ b/src/main/java/com/cheeeese/cheese4cut/infrastructure/mapper/Cheese4cutMapper.java
@@ -2,7 +2,7 @@ package com.cheeeese.cheese4cut.infrastructure.mapper;
 
 import com.cheeeese.album.domain.Album;
 import com.cheeeese.cheese4cut.domain.Cheese4cut;
-import com.cheeeese.cheese4cut.dto.request.Cheese4cutFixedRequest;
+import com.cheeeese.cheese4cut.domain.Cheese4cutPhoto;
 import com.cheeeese.cheese4cut.dto.response.Cheese4cutFinalResponse;
 import com.cheeeese.cheese4cut.dto.response.Cheese4cutPresignedUrlResponse;
 import com.cheeeese.cheese4cut.dto.response.Cheese4cutPreviewResponse;
@@ -10,6 +10,7 @@ import com.cheeeese.photo.domain.Photo;
 
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 public class Cheese4cutMapper {
 
@@ -18,10 +19,17 @@ public class Cheese4cutMapper {
     /**
      * 확정 후 응답 (Cheese4cut 엔티티 기반)
      */
-    // TODO: 프레임 이미지 제거에 따른 응답 형식 수정하기
-    public static Cheese4cutFinalResponse toFinalResponse() {
+    public static Cheese4cutFinalResponse toFinalResponse(Cheese4cut cheese4cut) {
         return Cheese4cutFinalResponse.builder()
                 .isFinalized(true)
+                .photos(cheese4cut.getPhotos().stream()
+                        .map(photo -> Cheese4cutFinalResponse.FinalPhotoInfo.builder()
+                                .photoId(photo.getPhotoId())
+                                .imageUrl(photo.getImageUrl())
+                                .thumbnailImageUrl(photo.getThumbnailImageUrl())
+                                .photoRank(photo.getPhotoRank())
+                                .build())
+                        .collect(Collectors.toList()))
                 .build();
     }
 
@@ -49,22 +57,22 @@ public class Cheese4cutMapper {
     }
 
     /**
-     * 사용자가 직접 확정할 때 요청 DTO 기반 엔티티 변환
+     * 확정 시 (좋아요 TOP4 또는 사용자가 선택한 사진 목록 기반)
      */
-    public static Cheese4cut toEntity(Album album, Cheese4cutFixedRequest request) {
+    public static Cheese4cut toEntity(Album album, List<Photo> orderedPhotos) {
         return Cheese4cut.builder()
                 .album(album)
-                .photoIds(request.photoIds())
-                .build();
-    }
-
-    /**
-     * 만료 자동 확정 시 (top4 사진 및 기본 프레임 기반)
-     */
-    public static Cheese4cut toEntity(Album album, List<Long> photoIds) {
-        return Cheese4cut.builder()
-                .album(album)
-                .photoIds(photoIds)
+                .photos(IntStream.range(0, orderedPhotos.size())
+                        .mapToObj(index -> {
+                            Photo photo = orderedPhotos.get(index);
+                            return Cheese4cutPhoto.builder()
+                                    .photoId(photo.getId())
+                                    .imageUrl(photo.getImageUrl())
+                                    .thumbnailImageUrl(photo.getThumbnailUrl())
+                                    .photoRank(index + 1)
+                                    .build();
+                        })
+                        .collect(Collectors.toList()))
                 .build();
     }
 

--- a/src/main/java/com/cheeeese/cheese4cut/presentation/Cheese4cutController.java
+++ b/src/main/java/com/cheeeese/cheese4cut/presentation/Cheese4cutController.java
@@ -12,6 +12,7 @@ import com.cheeeese.user.domain.User;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -29,10 +30,11 @@ public class Cheese4cutController implements Cheese4cutSwagger {
     @Override
     @GetMapping("/preview")
     public CommonResponse<Cheese4cutResponse> getCheese4cut(
+            Authentication authentication,
             @PathVariable @NotBlank String code
     ) {
         return CommonResponse.success(SuccessCode.CHEESE4CUT_GET_SUCCESS,
-                cheese4cutService.getCheese4cutByAlbumCode(code));
+                cheese4cutService.getCheese4cutByAlbumCode(authentication, code));
     }
 
     @Override

--- a/src/main/java/com/cheeeese/cheese4cut/presentation/swagger/Cheese4cutSwagger.java
+++ b/src/main/java/com/cheeeese/cheese4cut/presentation/swagger/Cheese4cutSwagger.java
@@ -9,12 +9,12 @@ import com.cheeeese.user.domain.User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -75,6 +75,7 @@ public interface Cheese4cutSwagger {
             )
     })
     CommonResponse<Cheese4cutResponse> getCheese4cut(
+            Authentication authentication,
             @PathVariable @NotBlank String code
     );
 

--- a/src/main/java/com/cheeeese/photo/infrastructure/persistence/PhotoRepository.java
+++ b/src/main/java/com/cheeeese/photo/infrastructure/persistence/PhotoRepository.java
@@ -96,7 +96,7 @@ public interface PhotoRepository extends JpaRepository<Photo, Long> {
     WHERE p.album.id = :albumId
     AND p.isDeleted = FALSE
     AND p.status = :status
-    ORDER BY p.likesCnt DESC, p.createdAt ASC
+    ORDER BY p.likesCnt DESC, p.createdAt DESC
     """)
     List<Long> findTop4CompletedPhotoIdsByLikes(
             @Param("albumId") Long albumId,

--- a/src/main/java/com/cheeeese/photo/infrastructure/persistence/PhotoRepository.java
+++ b/src/main/java/com/cheeeese/photo/infrastructure/persistence/PhotoRepository.java
@@ -105,4 +105,13 @@ public interface PhotoRepository extends JpaRepository<Photo, Long> {
     );
 
     List<Photo> findAllByIdIn(List<Long> photoIds);
+
+    @Query("""
+    SELECT p
+    FROM Photo p
+    WHERE p.id IN :photoIds
+      AND p.isDeleted = FALSE
+    ORDER BY p.likesCnt DESC, p.createdAt DESC, p.id DESC
+    """)
+    List<Photo> findAllByIdInOrderByLikesDescCreatedDesc(@Param("photoIds") List<Long> photoIds);
 }


### PR DESCRIPTION
## 🔗 연관된 이슈
- #57 

## 🚀 변경 유형
- [x] ✨ 기능 추가 (feature)
- [x] 🐛 버그 수정 (fix)
- [ ] 📝 문서 변경 (docs)
- [ ] ♻️ 리팩토링 (refactor)
- [ ] 🧪 테스트 추가 / 수정 (test)
- [ ] ⚙️ 설정 변경 (chore)

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 멘토링때 받은 피드백을 고려하여 redis를 그대로 사용하기로 했습니다. 다만 성능 측면에서 고민을 해본 결과 redis TTL 기반으로 tracking 하는 것이 아닌 sorted set을 사용하기로 하였습니다.
- 최종 치즈네컷 프레임 한장을 백엔드에서 저장하지 않기로 함에 따라 cheese4cutPhoto 엔티티를 추가하여 원본 이미지 url과 혹시 모를 thumbnailImageUrl을 저장했습니다.

[작업한 내용]
- 치즈네컷 조회
- 치즈네컷 확정
- 치즈네컷 생성 (만료 7일이 되었을 때)

## 📸 스크린샷
> Redis에 저장
<img width="1213" height="289" alt="스크린샷 2025-11-13 오전 12 40 32" src="https://github.com/user-attachments/assets/3d9f8a64-d755-4754-a850-b1a62e0852b6" />

> 치즈네컷이 생성되기 전 치즈네컷 조회 response (cdn 추가하여 response 제공)
<img width="640" height="371" alt="스크린샷 2025-11-13 오전 10 29 12" src="https://github.com/user-attachments/assets/492267b8-7898-4346-9dca-ae02989618b2" />

> 치즈네컷이 확정된 후(MAKER 혹은 앨범 만료) 치즈네컷 조회 response
<img width="608" height="431" alt="스크린샷 2025-11-13 오후 9 47 42" src="https://github.com/user-attachments/assets/8848281e-f7e3-4595-9fc5-14258e31fcf4" />

> 치즈네컷 확정 api
<img width="590" height="271" alt="스크린샷 2025-11-13 오후 9 44 05" src="https://github.com/user-attachments/assets/2bd456ca-54d0-4b0a-a5e2-4116c5cfad85" />

<img width="592" height="252" alt="스크린샷 2025-11-13 오후 9 46 56" src="https://github.com/user-attachments/assets/fb10c63a-1827-462f-a4cc-48483b5de361" />

## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->

### 📜 리뷰 규칙

Reviewer는 아래 **P5 Rule**을 참고하여 리뷰를 진행합니다.
P5 Rule을 통해 Reviewer는 Reviewee에게 리뷰의 의도를 보다 정확히 전달할 수 있습니다.

> - **P1:** 꼭 반영해주세요 (Comment)
> - **P2:** 적극적으로 고려해주세요 (Comment)
> - **P3:** 웬만하면 반영해 주세요 (Comment)
> - **P4:** 반영해도 좋고 넘어가도 좋습니다 (Approve)
> - **P5:** 그냥 사소한 의견입니다 (Approve)

- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * Cheese4cut 미리보기에 사용자 역할 및 사진 순위 정보 추가
  * Cheese4cut 최종 응답에 정렬된 사진 세부정보 포함

* **개선 사항**
  * 사진 정렬 및 검증 메커니즘 강화
  * 앨범 만료 처리 절차 개선
  * 사용자 인증 기반 콘텐츠 처리 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->