### PR TITLE
feat: 온보딩 API 수정

### DIFF
--- a/src/main/java/com/cheeeese/album/application/AlbumService.java
+++ b/src/main/java/com/cheeeese/album/application/AlbumService.java
@@ -13,6 +13,7 @@ import com.cheeeese.album.infrastructure.mapper.UserAlbumMapper;
 import com.cheeeese.album.infrastructure.persistence.AlbumExpirationRedisRepository;
 import com.cheeeese.album.infrastructure.persistence.AlbumRepository;
 import com.cheeeese.global.security.CustomUserDetails;
+import com.cheeeese.global.util.ProfileImageUtil;
 import com.cheeeese.global.util.resolver.CdnUrlResolver;
 import com.cheeeese.photo.application.PhotoService;
 import com.cheeeese.album.domain.UserAlbum;
@@ -24,6 +25,7 @@ import com.cheeeese.photo.infrastructure.mapper.PhotoMapper;
 import com.cheeeese.photo.infrastructure.persistence.PhotoLikesRepository;
 import com.cheeeese.photo.infrastructure.persistence.PhotoRepository;
 import com.cheeeese.user.domain.User;
+import com.cheeeese.user.domain.type.ProfileImageType;
 import com.cheeeese.user.exception.UserException;
 import com.cheeeese.user.exception.code.UserErrorCode;
 import com.cheeeese.user.infrastructure.persistence.UserRepository;
@@ -103,8 +105,9 @@ public class AlbumService {
             return AlbumMapper.toExpiredInvitationResponse(album);
         }
         User maker = getMaker(album.getMakerId());
+        String makerProfileUrl = ProfileImageUtil.resolveProfileImage(maker, cdnUrlResolver);
 
-        return AlbumMapper.toInvitationResponse(album, maker);
+        return AlbumMapper.toInvitationResponse(album, maker, makerProfileUrl);
     }
 
     @Transactional
@@ -113,7 +116,10 @@ public class AlbumService {
         albumValidator.validateAlbumEntry(album, currentUser);
 
         Optional<UserAlbum> existing = userAlbumRepository.findByUserIdAndAlbumId(currentUser.getId(), album.getId());
-        AlbumMakerInfo makerInfo = AlbumMapper.toMakerInfo(getMaker(album.getMakerId()));
+
+        User maker = getMaker(album.getMakerId());
+        String makerProfileUrl = ProfileImageUtil.resolveProfileImage(maker, cdnUrlResolver);
+        AlbumMakerInfo makerInfo = AlbumMapper.toMakerInfo(maker, makerProfileUrl);
 
         // Case 1: 기존 참여 이력 존재
         if (existing.isPresent()) {
@@ -267,13 +273,20 @@ public class AlbumService {
         // 1~4개인 경우, 1개만 반환하는 비즈니스 로직 적용
         if (photos.size() < 5) {
             Photo photo = photos.get(0);
-            return List.of(AlbumMapper.toRecentPhotoResponse(photo));
+            String profileUrl = ProfileImageUtil.resolveProfileImage(photo.getUser(), cdnUrlResolver);
+            return List.of(AlbumMapper.toRecentPhotoResponse(photo, profileUrl));
         }
 
         // 5개인 경우, 5개 모두 반환
         return photos.stream()
-                .map(AlbumMapper::toRecentPhotoResponse)
-                .collect(Collectors.toList());
+                .map(photo -> {
+                    String profileUrl = ProfileImageUtil.resolveProfileImage(
+                            photo.getUser(),
+                            cdnUrlResolver
+                    );
+                    return AlbumMapper.toRecentPhotoResponse(photo, profileUrl);
+                })
+                .toList();
     }
 
     private List<AlbumParticipantListResponse.ParticipantInfo> buildSortedParticipantInfos(
@@ -284,8 +297,11 @@ public class AlbumService {
                 .map(userAlbum -> {
                     User user = userAlbum.getUser();
                     Role role = userAlbum.getRole();
+                    ProfileImageType type = ProfileImageType.fromName(user.getProfileImage());
+                    String profileImageUrl = cdnUrlResolver.resolveProfile(type.getPath());
                     boolean isMe = currentUserId != null && user.getId().equals(currentUserId);
-                    return UserAlbumMapper.toParticipantInfo(user, role, isMe);
+
+                    return UserAlbumMapper.toParticipantInfo(user, profileImageUrl, role, isMe);
                 })
                 .sorted(Comparator
                         .comparing(AlbumParticipantListResponse.ParticipantInfo::isMe, Comparator.reverseOrder())

--- a/src/main/java/com/cheeeese/album/dto/response/AlbumInfoResponse.java
+++ b/src/main/java/com/cheeeese/album/dto/response/AlbumInfoResponse.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Builder
 @Schema(description = "앨범 정보 API")
@@ -27,6 +28,9 @@ public record AlbumInfoResponse(
         LocalDate eventDate,
 
         @Schema(description = "현재 사진 수", example = "1212")
-        int currentPhotoCnt
+        int currentPhotoCnt,
+
+        @Schema(description = "앨범 만료일자", example = "2025-11-17 16:53:35.430336")
+        LocalDateTime expiredAt
 ) {
 }

--- a/src/main/java/com/cheeeese/album/infrastructure/mapper/AlbumMapper.java
+++ b/src/main/java/com/cheeeese/album/infrastructure/mapper/AlbumMapper.java
@@ -58,14 +58,14 @@ public class AlbumMapper {
     /**
      * Album 엔티티와 Maker User 정보를 초대장 응답 DTO로 변환합니다.
      */
-    public static AlbumInvitationResponse toInvitationResponse(Album album, User user) {
+    public static AlbumInvitationResponse toInvitationResponse(Album album, User user, String profileImage) {
         return AlbumInvitationResponse.builder()
                 .title(album.getTitle())
                 .themeEmoji(album.getThemeEmoji())
                 .eventDate(album.getEventDate().toString())
                 .expiredAt(album.getExpiredAt())
                 .makerName(user.getName())
-                .makerProfileImage(user.getProfileImage())
+                .makerProfileImage(profileImage)
                 .isExpired(false)
                 .build();
     }
@@ -114,23 +114,23 @@ public class AlbumMapper {
                 .build();
     }
 
-    public static NewEnterResponse.RecentPhotoResponse toRecentPhotoResponse(Photo photo) {
+    public static NewEnterResponse.RecentPhotoResponse toRecentPhotoResponse(Photo photo, String profileImage) {
         User uploader = photo.getUser();
 
         return NewEnterResponse.RecentPhotoResponse.builder()
                 .thumbnailUrl(photo.getThumbnailUrl())
                 .uploaderName(uploader.getName())
-                .uploaderProfileImage(uploader.getProfileImage())
+                .uploaderProfileImage(profileImage)
                 .build();
     }
 
     /**
      * 메이커 User 엔티티를 호스트 정보 응답 DTO로 변환합니다.
      */
-    public static AlbumMakerInfo toMakerInfo(User user) {
+    public static AlbumMakerInfo toMakerInfo(User user, String profileImage) {
         return AlbumMakerInfo.builder()
                 .makerName(user.getName())
-                .makerProfileImage(user.getProfileImage())
+                .makerProfileImage(profileImage)
                 .build();
     }
 

--- a/src/main/java/com/cheeeese/album/infrastructure/mapper/UserAlbumMapper.java
+++ b/src/main/java/com/cheeeese/album/infrastructure/mapper/UserAlbumMapper.java
@@ -20,11 +20,11 @@ public class UserAlbumMapper {
                 .build();
     }
 
-    public static AlbumParticipantListResponse.ParticipantInfo toParticipantInfo(User user, Role role, boolean isMe) {
+    public static AlbumParticipantListResponse.ParticipantInfo toParticipantInfo(User user, String profileImage, Role role, boolean isMe) {
         return AlbumParticipantListResponse.ParticipantInfo.builder()
                 .name(user.getName())
                 .role(role)
-                .profileImage(user.getProfileImage())
+                .profileImage(profileImage)
                 .isMe(isMe)
                 .build();
     }

--- a/src/main/java/com/cheeeese/global/common/code/SuccessCode.java
+++ b/src/main/java/com/cheeeese/global/common/code/SuccessCode.java
@@ -17,7 +17,9 @@ public enum SuccessCode implements BaseCode {
     LOGOUT_SUCCESS(HttpStatus.OK, "로그아웃이 성공적으로 완료되었습니다."),
 
     // user
-    USER_PROFILE_UPDATE_SUCCESS(HttpStatus.OK, "사용자 프로필 업데이트가 성공적으로 완료되었습니다."),
+    USER_NAME_UPDATE_SUCCESS(HttpStatus.OK, "사용자 이름 업데이트가 성공적으로 완료되었습니다."),
+    USER_PROFILE_IMAGE_OPT_GET_SUCCESS(HttpStatus.OK, "사용자 프로필 이미지 선택 옵션 목록 조회가 성공적으로 완료되었습니다."),
+    USER_PROFILE_IMAGE_UPDATE_SUCCESS(HttpStatus.OK, "사용자 프로필 이미지 업데이트가 성공적으로 완료되었습니다."),
     USER_AGREEMENT_ACCEPT_SUCCESS(HttpStatus.OK, "사용자 이용 약관 동의가 성공적으로 완료되었습니다."),
 
     // album

--- a/src/main/java/com/cheeeese/global/config/SecurityConfig.java
+++ b/src/main/java/com/cheeeese/global/config/SecurityConfig.java
@@ -39,7 +39,8 @@ public class SecurityConfig {
             "/v1/album/*/invitation",
             "/v1/cheese4cut/*/preview",
             "/v1/album/*/participants",
-            "/internal/thumbnail/complete"
+            "/internal/thumbnail/complete",
+            "/v1/user/profile-images"
     };
 
     @Bean

--- a/src/main/java/com/cheeeese/global/util/ProfileImageUtil.java
+++ b/src/main/java/com/cheeeese/global/util/ProfileImageUtil.java
@@ -8,6 +8,7 @@ public class ProfileImageUtil {
 
     public static String resolveProfileImage(User user, CdnUrlResolver resolver) {
         ProfileImageType type = ProfileImageType.fromName(user.getProfileImage());
+        if (type == null) return null;
         return resolver.resolveProfile(type.getPath());
     }
 }

--- a/src/main/java/com/cheeeese/global/util/ProfileImageUtil.java
+++ b/src/main/java/com/cheeeese/global/util/ProfileImageUtil.java
@@ -1,0 +1,13 @@
+package com.cheeeese.global.util;
+
+import com.cheeeese.global.util.resolver.CdnUrlResolver;
+import com.cheeeese.user.domain.User;
+import com.cheeeese.user.domain.type.ProfileImageType;
+
+public class ProfileImageUtil {
+
+    public static String resolveProfileImage(User user, CdnUrlResolver resolver) {
+        ProfileImageType type = ProfileImageType.fromName(user.getProfileImage());
+        return resolver.resolveProfile(type.getPath());
+    }
+}

--- a/src/main/java/com/cheeeese/global/util/resolver/CdnUrlResolver.java
+++ b/src/main/java/com/cheeeese/global/util/resolver/CdnUrlResolver.java
@@ -12,8 +12,8 @@ public class CdnUrlResolver {
     @Value("${cdn.thumbnail-domain}")
     private String thumbnailDomain;
 
-    @Value("${cdn.4cut-domain}")
-    private String cutDomain;
+    @Value("${cdn.profile-domain}")
+    private String profileDomain;
 
     public String resolveOriginal(String path) {
         return resolve(originalDomain, path);
@@ -23,8 +23,8 @@ public class CdnUrlResolver {
         return resolve(thumbnailDomain, path);
     }
 
-    public String resolveCut(String path) {
-        return resolve(cutDomain, path);
+    public String resolveProfile(String path) {
+        return resolve(profileDomain, path);
     }
 
     private String resolve(String domain, String path) {

--- a/src/main/java/com/cheeeese/photo/application/PhotoInfoService.java
+++ b/src/main/java/com/cheeeese/photo/application/PhotoInfoService.java
@@ -3,7 +3,7 @@ package com.cheeeese.photo.application;
 import com.cheeeese.album.application.validator.AlbumValidator;
 import com.cheeeese.album.domain.Album;
 import com.cheeeese.album.domain.type.Role;
-import com.cheeeese.global.security.CurrentUserProvider;
+import com.cheeeese.global.util.resolver.CdnUrlResolver;
 import com.cheeeese.photo.domain.Photo;
 import com.cheeeese.photo.dto.response.PhotoLikedUserResponse;
 import com.cheeeese.photo.exception.PhotoException;
@@ -12,6 +12,7 @@ import com.cheeeese.photo.infrastructure.mapper.PhotoMapper;
 import com.cheeeese.photo.infrastructure.persistence.PhotoLikesRepository;
 import com.cheeeese.photo.infrastructure.persistence.PhotoRepository;
 import com.cheeeese.user.domain.User;
+import com.cheeeese.user.domain.type.ProfileImageType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,10 +24,10 @@ import java.util.List;
 @Transactional(readOnly = true)
 public class PhotoInfoService {
 
-    private final CurrentUserProvider currentUserProvider;
     private final PhotoRepository photoRepository;
     private final PhotoLikesRepository photoLikesRepository;
     private final AlbumValidator albumValidator;
+    private final CdnUrlResolver cdnUrlResolver;
 
     public PhotoLikedUserResponse getPhotoLikedUsers(User user, String code, Long photoId) {
         Album album = albumValidator.validateAlbumCode(code);
@@ -40,9 +41,12 @@ public class PhotoInfoService {
 
         List<PhotoLikedUserResponse.PhotoLiker> likers = users.stream()
                 .map(liker -> {
+                    ProfileImageType type = ProfileImageType.fromName(user.getProfileImage());
+                    String profileImageUrl = cdnUrlResolver.resolveProfile(type.getPath());
                     boolean isMe = liker.getId().equals(user.getId());
                     Role role = liker.getId().equals(album.getMakerId()) ? Role.MAKER : Role.GUEST;
-                    return PhotoMapper.toPhotoLiker(liker, isMe, role);
+
+                    return PhotoMapper.toPhotoLiker(liker, profileImageUrl, isMe, role);
                 })
                 .toList();
 

--- a/src/main/java/com/cheeeese/photo/application/PhotoInfoService.java
+++ b/src/main/java/com/cheeeese/photo/application/PhotoInfoService.java
@@ -41,7 +41,7 @@ public class PhotoInfoService {
 
         List<PhotoLikedUserResponse.PhotoLiker> likers = users.stream()
                 .map(liker -> {
-                    ProfileImageType type = ProfileImageType.fromName(user.getProfileImage());
+                    ProfileImageType type = ProfileImageType.fromName(liker.getProfileImage());
                     String profileImageUrl = cdnUrlResolver.resolveProfile(type.getPath());
                     boolean isMe = liker.getId().equals(user.getId());
                     Role role = liker.getId().equals(album.getMakerId()) ? Role.MAKER : Role.GUEST;

--- a/src/main/java/com/cheeeese/photo/application/PhotoQueryService.java
+++ b/src/main/java/com/cheeeese/photo/application/PhotoQueryService.java
@@ -36,14 +36,14 @@ public class PhotoQueryService {
     private final RedisCacheUtil redisCacheUtil;
     private final CdnUrlResolver cdnUrlResolver;
 
-    private static final String PHOTO_KEY = "cache:album:%s:photos:sort:%s:page:%d:version:%d";
+    private static final String PHOTO_KEY = "cache:album:%s:photos:sort:%s:page:%d:size:%d:version:%d";
     private static final String VERSION_KEY = "cache:album:%s:version";
 
     public PhotoPageResponse getPhotoPage(User user, String code, int page, int size, AlbumSorting albumSorting) {
         String versionKey = String.format(VERSION_KEY, code);
         Long curVersion = Optional.ofNullable(redisCacheUtil.getValue(versionKey)).orElse(0L);
 
-        String photoKey = String.format(PHOTO_KEY, code, albumSorting.getParam(), page, curVersion);
+        String photoKey = String.format(PHOTO_KEY, code, albumSorting.getParam(), page, size, curVersion);
         PhotoPageResponse cachedList = redisCacheUtil.getObject(photoKey, PhotoPageResponse.class);
 
         // redis에 존재할 경우, db 접근 X + 바로 반환

--- a/src/main/java/com/cheeeese/photo/application/PhotoService.java
+++ b/src/main/java/com/cheeeese/photo/application/PhotoService.java
@@ -24,6 +24,7 @@ import com.cheeeese.photo.infrastructure.persistence.PhotoLikesRepository;
 import com.cheeeese.photo.infrastructure.persistence.PhotoRepository;
 import com.cheeeese.user.application.UserService;
 import com.cheeeese.user.domain.User;
+import com.cheeeese.user.infrastructure.persistence.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.PageRequest;
@@ -41,6 +42,7 @@ import java.util.stream.Collectors;
 public class PhotoService {
 
     private final UserService userService;
+    private final UserRepository userRepository;
     private final PhotoRepository photoRepository;
     private final PhotoLikesRepository photoLikesRepository;
     private final PhotoHistoryRepository photoHistoryRepository;
@@ -134,6 +136,8 @@ public class PhotoService {
         photoRepository.incrementLikeCnt(photo.getId());
         photoLikesRepository.save(photoLikes);
 
+        userRepository.incrementLikeCnt(photo.getUser().getId());
+
         photoQueryService.invalidatePhotoCache(photo.getAlbum().getCode());
     }
 
@@ -147,6 +151,8 @@ public class PhotoService {
 
         photoRepository.decrementLikeCnt(photo.getId());
         photoLikesRepository.delete(photoLikes);
+
+        userRepository.decrementLikeCnt(photo.getUser().getId());
 
         photoQueryService.invalidatePhotoCache(photo.getAlbum().getCode());
     }

--- a/src/main/java/com/cheeeese/photo/infrastructure/mapper/PhotoMapper.java
+++ b/src/main/java/com/cheeeese/photo/infrastructure/mapper/PhotoMapper.java
@@ -159,6 +159,7 @@ public class PhotoMapper {
                 .currentParticipant(album.getCurrentParticipant())
                 .eventDate(album.getEventDate())
                 .currentPhotoCnt(album.getCurrentPhotoCount())
+                .expiredAt(album.getExpiredAt())
                 .build();
     }
 

--- a/src/main/java/com/cheeeese/photo/infrastructure/mapper/PhotoMapper.java
+++ b/src/main/java/com/cheeeese/photo/infrastructure/mapper/PhotoMapper.java
@@ -162,10 +162,10 @@ public class PhotoMapper {
                 .build();
     }
 
-    public static PhotoLikedUserResponse.PhotoLiker toPhotoLiker(User user, boolean isMe, Role role) {
+    public static PhotoLikedUserResponse.PhotoLiker toPhotoLiker(User user, String profileImageUrl, boolean isMe, Role role) {
         return PhotoLikedUserResponse.PhotoLiker.builder()
                 .name(user.getName())
-                .profileImageUrl(user.getProfileImage())
+                .profileImageUrl(profileImageUrl)
                 .isMe(isMe)
                 .role(role)
                 .build();

--- a/src/main/java/com/cheeeese/user/application/UserService.java
+++ b/src/main/java/com/cheeeese/user/application/UserService.java
@@ -1,15 +1,23 @@
 package com.cheeeese.user.application;
 
+import com.cheeeese.global.util.resolver.CdnUrlResolver;
 import com.cheeeese.user.application.validator.UserValidator;
 import com.cheeeese.user.domain.User;
+import com.cheeeese.user.domain.type.ProfileImageType;
 import com.cheeeese.user.dto.request.UserAgreementRequest;
+import com.cheeeese.user.dto.request.UserProfileImageRequest;
 import com.cheeeese.user.dto.request.UserProfileRequest;
+import com.cheeeese.user.dto.response.UserProfileImageResponse;
 import com.cheeeese.user.exception.UserException;
 import com.cheeeese.user.exception.code.UserErrorCode;
+import com.cheeeese.user.infrastructure.mapper.UserMapper;
 import com.cheeeese.user.infrastructure.persistence.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Arrays;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -18,11 +26,28 @@ public class UserService {
 
     private final UserValidator userValidator;
     private final UserRepository userRepository;
+    private final CdnUrlResolver cdnUrlResolver;;
 
     @Transactional
-    public void updateUserProfile(User user, UserProfileRequest request) {
-        // TODO: 이미지 수정 추후 추가
-        user.updateUserProfile(request.name());
+    public void updateUserName(User user, UserProfileRequest request) {
+        user.updateUserName(request.name());
+    }
+
+    public UserProfileImageResponse getUserProfileImageOpt() {
+        List<UserProfileImageResponse.ProfileImageOpt> opts =
+                Arrays.stream(ProfileImageType.values())
+                        .map(type -> {
+                            String resolvedUrl = cdnUrlResolver.resolveProfile(type.getPath());
+                            return UserMapper.toProfileImageOpt(type, resolvedUrl);
+                        })
+                        .toList();
+
+        return UserMapper.toProfileImageResponse(opts);
+    }
+
+    @Transactional
+    public void updateUserProfileImage(User user, UserProfileImageRequest request) {
+        user.updateUserProfileImage(request.imageCode());
     }
 
     @Transactional

--- a/src/main/java/com/cheeeese/user/application/UserService.java
+++ b/src/main/java/com/cheeeese/user/application/UserService.java
@@ -47,7 +47,8 @@ public class UserService {
 
     @Transactional
     public void updateUserProfileImage(User user, UserProfileImageRequest request) {
-        user.updateUserProfileImage(request.imageCode());
+        ProfileImageType type = ProfileImageType.fromName(request.imageCode());
+        user.updateUserProfileImage(type.name());
     }
 
     @Transactional

--- a/src/main/java/com/cheeeese/user/application/UserService.java
+++ b/src/main/java/com/cheeeese/user/application/UserService.java
@@ -26,7 +26,7 @@ public class UserService {
 
     private final UserValidator userValidator;
     private final UserRepository userRepository;
-    private final CdnUrlResolver cdnUrlResolver;;
+    private final CdnUrlResolver cdnUrlResolver;
 
     @Transactional
     public void updateUserName(User user, UserProfileRequest request) {

--- a/src/main/java/com/cheeeese/user/application/validator/UserValidator.java
+++ b/src/main/java/com/cheeeese/user/application/validator/UserValidator.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
 public class UserValidator {
 
     public void validateUserAgreement(UserAgreementRequest request) {
-        if (!request.isServiceAgreement() || !request.isUserInfoAgreement()) {
+        if (!request.isServiceAgreement() || !request.isUserInfoAgreement() || !request.isThirdPartyAgreement()) {
             throw new UserException(UserErrorCode.REQUIRED_TERMS_NOT_AGREED);
         }
     }

--- a/src/main/java/com/cheeeese/user/domain/User.java
+++ b/src/main/java/com/cheeeese/user/domain/User.java
@@ -82,8 +82,12 @@ public class User extends BaseEntity {
         this.likesCnt = likesCnt;
     }
 
-    public void updateUserProfile(String name) {
+    public void updateUserName(String name) {
         this.name = name;
+    }
+
+    public void updateUserProfileImage(String profileImage) {
+        this.profileImage = profileImage;
     }
 
     public void saveUserAgreement(

--- a/src/main/java/com/cheeeese/user/domain/type/ProfileImageType.java
+++ b/src/main/java/com/cheeeese/user/domain/type/ProfileImageType.java
@@ -5,16 +5,16 @@ import lombok.Getter;
 @Getter
 public enum ProfileImageType {
 
-    P1("signup_profile_1.jpg"),
-    P2("signup_profile_2.jpg"),
-    P3("signup_profile_3.jpg"),
-    P4("signup_profile_4.jpg"),
-    P5("signup_profile_5.jpg"),
-    P6("signup_profile_6.jpg"),
-    P7("signup_profile_7.jpg"),
-    P8("signup_profile_8.jpg"),
-    P9("signup_profile_9.jpg"),
-    P10("signup_profile_10.jpg");
+    P1("profile/signup_profile_1.jpg"),
+    P2("profile/signup_profile_2.jpg"),
+    P3("profile/signup_profile_3.jpg"),
+    P4("profile/signup_profile_4.jpg"),
+    P5("profile/signup_profile_5.jpg"),
+    P6("profile/signup_profile_6.jpg"),
+    P7("profile/signup_profile_7.jpg"),
+    P8("profile/signup_profile_8.jpg"),
+    P9("profile/signup_profile_9.jpg"),
+    P10("profile/signup_profile_10.jpg");
 
     private final String path;
 

--- a/src/main/java/com/cheeeese/user/domain/type/ProfileImageType.java
+++ b/src/main/java/com/cheeeese/user/domain/type/ProfileImageType.java
@@ -1,0 +1,28 @@
+package com.cheeeese.user.domain.type;
+
+import lombok.Getter;
+
+@Getter
+public enum ProfileImageType {
+
+    P1("signup_profile_1.jpg"),
+    P2("signup_profile_2.jpg"),
+    P3("signup_profile_3.jpg"),
+    P4("signup_profile_4.jpg"),
+    P5("signup_profile_5.jpg"),
+    P6("signup_profile_6.jpg"),
+    P7("signup_profile_7.jpg"),
+    P8("signup_profile_8.jpg"),
+    P9("signup_profile_9.jpg"),
+    P10("signup_profile_10.jpg");
+
+    private final String path;
+
+    ProfileImageType(String path) {
+        this.path = path;
+    }
+
+    public static ProfileImageType fromName(String name) {
+        return ProfileImageType.valueOf(name);
+    }
+}

--- a/src/main/java/com/cheeeese/user/domain/type/ProfileImageType.java
+++ b/src/main/java/com/cheeeese/user/domain/type/ProfileImageType.java
@@ -4,7 +4,6 @@ import lombok.Getter;
 
 @Getter
 public enum ProfileImageType {
-
     P1("profile/signup_profile_1.jpg"),
     P2("profile/signup_profile_2.jpg"),
     P3("profile/signup_profile_3.jpg"),
@@ -23,6 +22,12 @@ public enum ProfileImageType {
     }
 
     public static ProfileImageType fromName(String name) {
-        return ProfileImageType.valueOf(name);
+        if (name == null || name.isBlank()) return null;
+
+        try {
+            return ProfileImageType.valueOf(name);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
     }
 }

--- a/src/main/java/com/cheeeese/user/dto/request/UserAgreementRequest.java
+++ b/src/main/java/com/cheeeese/user/dto/request/UserAgreementRequest.java
@@ -27,6 +27,7 @@ public record UserAgreementRequest(
         )
         boolean isMarketingAgreement,
 
+        @NotNull
         @Schema(
                 description = "제3자 제공 동의",
                 example = "false"

--- a/src/main/java/com/cheeeese/user/dto/request/UserProfileImageRequest.java
+++ b/src/main/java/com/cheeeese/user/dto/request/UserProfileImageRequest.java
@@ -1,9 +1,12 @@
 package com.cheeeese.user.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder
+@Schema(description = "사용자 프로필 이미지 수정 API")
 public record UserProfileImageRequest(
+        @Schema(description = "프로필 이미지 코드", example = "P1")
         String imageCode
 ) {
 }

--- a/src/main/java/com/cheeeese/user/dto/request/UserProfileImageRequest.java
+++ b/src/main/java/com/cheeeese/user/dto/request/UserProfileImageRequest.java
@@ -1,0 +1,9 @@
+package com.cheeeese.user.dto.request;
+
+import lombok.Builder;
+
+@Builder
+public record UserProfileImageRequest(
+        String imageCode
+) {
+}

--- a/src/main/java/com/cheeeese/user/dto/response/UserProfileImageResponse.java
+++ b/src/main/java/com/cheeeese/user/dto/response/UserProfileImageResponse.java
@@ -1,17 +1,43 @@
 package com.cheeeese.user.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 import java.util.List;
 
 @Builder
+@Schema(description = "사용자가 선택할 수 있는 프로필 이미지 목록 API")
 public record UserProfileImageResponse(
+        @Schema(
+                description = "프로필 이미지 옵션 목록",
+                example = """
+                        [
+                          {
+                            "imageCode": "P5",
+                            "profileImageUrl": "https://say-cheese-profile.edge.naverncp.com/profile/signup_profile_5.jpg"
+                          },
+                          {
+                            "imageCode": "P6",
+                            "profileImageUrl": "https://say-cheese-profile.edge.naverncp.com/profile/signup_profile_6.jpg"
+                          }
+                        ]
+                        """
+        )
         List<ProfileImageOpt> opts
 ) {
 
     @Builder
     public record ProfileImageOpt(
+            @Schema(
+                    description = "프로필 이미지 코드",
+                    example = "P5"
+            )
             String imageCode,
+
+            @Schema(
+                    description = "프로필 이미지의 CDN URL",
+                    example = "https://say-cheese-profile.edge.naverncp.com/profile/signup_profile_5.jpg"
+            )
             String profileImageUrl
     ) {}
 }

--- a/src/main/java/com/cheeeese/user/dto/response/UserProfileImageResponse.java
+++ b/src/main/java/com/cheeeese/user/dto/response/UserProfileImageResponse.java
@@ -1,0 +1,17 @@
+package com.cheeeese.user.dto.response;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record UserProfileImageResponse(
+        List<ProfileImageOpt> opts
+) {
+
+    @Builder
+    public record ProfileImageOpt(
+            String imageCode,
+            String profileImageUrl
+    ) {}
+}

--- a/src/main/java/com/cheeeese/user/infrastructure/mapper/UserMapper.java
+++ b/src/main/java/com/cheeeese/user/infrastructure/mapper/UserMapper.java
@@ -2,6 +2,10 @@ package com.cheeeese.user.infrastructure.mapper;
 
 import com.cheeeese.oauth2.domain.OAuth2UserInfo;
 import com.cheeeese.user.domain.User;
+import com.cheeeese.user.domain.type.ProfileImageType;
+import com.cheeeese.user.dto.response.UserProfileImageResponse;
+
+import java.util.List;
 
 public class UserMapper {
 
@@ -11,6 +15,19 @@ public class UserMapper {
                 .name(oAuth2UserInfo.getName())
                 .profileImage(oAuth2UserInfo.getProfileImage())
                 .providerId(oAuth2UserInfo.getProviderId())
+                .build();
+    }
+
+    public static UserProfileImageResponse.ProfileImageOpt toProfileImageOpt(ProfileImageType type, String imageUrl) {
+        return UserProfileImageResponse.ProfileImageOpt.builder()
+                .imageCode(type.name())
+                .profileImageUrl(imageUrl)
+                .build();
+    }
+
+    public static UserProfileImageResponse toProfileImageResponse(List<UserProfileImageResponse.ProfileImageOpt> opts) {
+        return UserProfileImageResponse.builder()
+                .opts(opts)
                 .build();
     }
 }

--- a/src/main/java/com/cheeeese/user/infrastructure/persistence/UserRepository.java
+++ b/src/main/java/com/cheeeese/user/infrastructure/persistence/UserRepository.java
@@ -27,7 +27,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     """)
     void incrementAlbumCnt(@Param("userId") Long userId);
 
-    @Modifying
+    @Modifying(flushAutomatically = true)
     @Query("""
         UPDATE User u
         SET u.likesCnt = u.likesCnt + 1
@@ -35,7 +35,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     """)
     void incrementLikeCnt(@Param("userId") Long userId);
 
-    @Modifying
+    @Modifying(flushAutomatically = true)
     @Query("""
         UPDATE User u
         SET u.likesCnt = u.likesCnt - 1

--- a/src/main/java/com/cheeeese/user/infrastructure/persistence/UserRepository.java
+++ b/src/main/java/com/cheeeese/user/infrastructure/persistence/UserRepository.java
@@ -26,4 +26,21 @@ public interface UserRepository extends JpaRepository<User, Long> {
         WHERE u.id = :userId
     """)
     void incrementAlbumCnt(@Param("userId") Long userId);
+
+    @Modifying
+    @Query("""
+        UPDATE User u
+        SET u.likesCnt = u.likesCnt + 1
+        WHERE u.id = :userId
+    """)
+    void incrementLikeCnt(@Param("userId") Long userId);
+
+    @Modifying
+    @Query("""
+        UPDATE User u
+        SET u.likesCnt = u.likesCnt - 1
+        WHERE u.id = :userId
+        AND u.likesCnt > 0
+    """)
+    void decrementLikeCnt(@Param("userId") Long userId);
 }

--- a/src/main/java/com/cheeeese/user/presentation/UserController.java
+++ b/src/main/java/com/cheeeese/user/presentation/UserController.java
@@ -24,7 +24,7 @@ public class UserController implements UserSwagger {
     private final UserService userService;
 
     @Override
-    @PatchMapping("/me/profile")
+    @PatchMapping("/me/name")
     public CommonResponse<Void> updateUserName(
             @CurrentUser User user,
             @RequestBody @Valid UserProfileRequest request

--- a/src/main/java/com/cheeeese/user/presentation/UserController.java
+++ b/src/main/java/com/cheeeese/user/presentation/UserController.java
@@ -11,10 +11,10 @@ import com.cheeeese.user.dto.response.UserProfileImageResponse;
 import com.cheeeese.user.presentation.swagger.UserSwagger;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
-import static com.cheeeese.global.common.code.SuccessCode.USER_AGREEMENT_ACCEPT_SUCCESS;
-import static com.cheeeese.global.common.code.SuccessCode.USER_PROFILE_UPDATE_SUCCESS;
+import static com.cheeeese.global.common.code.SuccessCode.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -25,26 +25,28 @@ public class UserController implements UserSwagger {
 
     @Override
     @PatchMapping("/me/profile")
-    public CommonResponse<Void> updateUserProfile(
+    public CommonResponse<Void> updateUserName(
             @CurrentUser User user,
             @RequestBody @Valid UserProfileRequest request
     ) {
         userService.updateUserName(user, request);
-        return CommonResponse.success(USER_PROFILE_UPDATE_SUCCESS);
+        return CommonResponse.success(USER_NAME_UPDATE_SUCCESS);
     }
 
+    @Override
     @GetMapping("/profile-images")
     public CommonResponse<UserProfileImageResponse> getUserProfileImage() {
-        return CommonResponse.success(USER_PROFILE_UPDATE_SUCCESS, userService.getUserProfileImageOpt());
+        return CommonResponse.success(USER_PROFILE_IMAGE_OPT_GET_SUCCESS, userService.getUserProfileImageOpt());
     }
 
+    @Override
     @PatchMapping("/me/profile-image")
     public CommonResponse<Void> updateUserProfileImage(
             @CurrentUser User user,
             @RequestBody @Valid UserProfileImageRequest request
     ) {
         userService.updateUserProfileImage(user, request);
-        return CommonResponse.success(USER_PROFILE_UPDATE_SUCCESS);
+        return CommonResponse.success(USER_PROFILE_IMAGE_UPDATE_SUCCESS);
     }
 
     @Override

--- a/src/main/java/com/cheeeese/user/presentation/UserController.java
+++ b/src/main/java/com/cheeeese/user/presentation/UserController.java
@@ -5,7 +5,9 @@ import com.cheeeese.global.util.CurrentUser;
 import com.cheeeese.user.application.UserService;
 import com.cheeeese.user.domain.User;
 import com.cheeeese.user.dto.request.UserAgreementRequest;
+import com.cheeeese.user.dto.request.UserProfileImageRequest;
 import com.cheeeese.user.dto.request.UserProfileRequest;
+import com.cheeeese.user.dto.response.UserProfileImageResponse;
 import com.cheeeese.user.presentation.swagger.UserSwagger;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -27,7 +29,21 @@ public class UserController implements UserSwagger {
             @CurrentUser User user,
             @RequestBody @Valid UserProfileRequest request
     ) {
-        userService.updateUserProfile(user, request);
+        userService.updateUserName(user, request);
+        return CommonResponse.success(USER_PROFILE_UPDATE_SUCCESS);
+    }
+
+    @GetMapping("/profile-images")
+    public CommonResponse<UserProfileImageResponse> getUserProfileImage() {
+        return CommonResponse.success(USER_PROFILE_UPDATE_SUCCESS, userService.getUserProfileImageOpt());
+    }
+
+    @PatchMapping("/me/profile-image")
+    public CommonResponse<Void> updateUserProfileImage(
+            @CurrentUser User user,
+            @RequestBody @Valid UserProfileImageRequest request
+    ) {
+        userService.updateUserProfileImage(user, request);
         return CommonResponse.success(USER_PROFILE_UPDATE_SUCCESS);
     }
 

--- a/src/main/java/com/cheeeese/user/presentation/swagger/UserSwagger.java
+++ b/src/main/java/com/cheeeese/user/presentation/swagger/UserSwagger.java
@@ -4,7 +4,9 @@ import com.cheeeese.global.common.CommonResponse;
 import com.cheeeese.global.util.CurrentUser;
 import com.cheeeese.user.domain.User;
 import com.cheeeese.user.dto.request.UserAgreementRequest;
+import com.cheeeese.user.dto.request.UserProfileImageRequest;
 import com.cheeeese.user.dto.request.UserProfileRequest;
+import com.cheeeese.user.dto.response.UserProfileImageResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -15,7 +17,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 @Tag(name = "[사용자]", description = "사용자 관련 API")
 public interface UserSwagger {
     @Operation(
-            summary = "사용자 프로필 수정 API",
+            summary = "사용자 이름 수정 API",
             description = """
                           ### RequestBody
                           ---
@@ -25,12 +27,43 @@ public interface UserSwagger {
     @ApiResponses(value = {
             @ApiResponse(
                     responseCode = "200",
-                    description = "사용자 프로필이 성공적으로 수정되었습니다."
+                    description = "사용자 이름이 성공적으로 수정되었습니다."
             )
     })
-    CommonResponse<Void> updateUserProfile(
+    CommonResponse<Void> updateUserName(
             @CurrentUser User user,
             @RequestBody @Valid UserProfileRequest request
+    );
+
+    @Operation(
+            summary = "프로필 이미지 조회 API",
+            description = "사용자가 선택할 수 있는 프로필 이미지를 조회합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "프로필 이미지 목록 조회가 성공적으로 수행되었습니다."
+            )
+    })
+    CommonResponse<UserProfileImageResponse> getUserProfileImage();
+
+    @Operation(
+            summary = "사용자 프로필 이미지 수정 API",
+            description = """
+                    ### RequestBody
+                    ---
+                    `imageCode`: 프로필 이미지 코드 (String)
+                    """
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "사용자 프로필 이미지 수정이 성공적으로 수행되었습니다."
+            )
+    })
+    CommonResponse<Void> updateUserProfileImage(
+            @CurrentUser User user,
+            @RequestBody @Valid UserProfileImageRequest request
     );
 
     @Operation(


### PR DESCRIPTION
## 🔗 연관된 이슈
- #61 

## 🚀 변경 유형
- [x] ✨ 기능 추가 (feature)
- [x] 🐛 버그 수정 (fix)
- [ ] 📝 문서 변경 (docs)
- [ ] ♻️ 리팩토링 (refactor)
- [ ] 🧪 테스트 추가 / 수정 (test)
- [ ] ⚙️ 설정 변경 (chore)

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 온보딩 API 수정
- 사진 조회 size 반영 오류 수정
- 좋아요 생성 시, 사용자 likesCnt++

## 📸 스크린샷
> <img width="456" height="337" alt="image" src="https://github.com/user-attachments/assets/bd5ef04d-30ea-48b0-846c-424397f60f1c" />
> <img width="798" height="501" alt="image" src="https://github.com/user-attachments/assets/2563bc65-c7c7-40f1-bcdb-380e6d3947c1" />

## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->

### 📜 리뷰 규칙

Reviewer는 아래 **P5 Rule**을 참고하여 리뷰를 진행합니다.
P5 Rule을 통해 Reviewer는 Reviewee에게 리뷰의 의도를 보다 정확히 전달할 수 있습니다.

> - **P1:** 꼭 반영해주세요 (Comment)
> - **P2:** 적극적으로 고려해주세요 (Comment)
> - **P3:** 웬만하면 반영해 주세요 (Comment)
> - **P4:** 반영해도 좋고 넘어가도 좋습니다 (Approve)
> - **P5:** 그냥 사소한 의견입니다 (Approve)

- 머 이상한 거 잇는지 함 봐주세요
- 내코드를내가모르겟어

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 프로필 이미지 선택 목록 제공 및 프로필 이미지 변경 API 추가
  * 초대, 참여자, 업로더, 최근 사진 등 UI에 프로필 이미지가 일관되게 노출
  * 사용자 이름 수정 API 분리 및 앨범 만료일(expiredAt) 표시 추가

* **버그 수정**
  * 사진 좋아요 시 소유자 좋아요 카운트 동기화 개선
  * 인증 화이트리스트에 프로필 이미지 조회 경로 추가

* **검증**
  * 동의 항목에 제3자 동의 필수 항목 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->