### PR TITLE
fix: 업로드 로직 수정

### DIFF
--- a/src/main/java/com/cheeeese/album/application/AlbumService.java
+++ b/src/main/java/com/cheeeese/album/application/AlbumService.java
@@ -156,7 +156,7 @@ public class AlbumService {
 
     public UploadAvailableCountResponse getAvailablePhotoCount(User user, String code) {
         Album album = albumValidator.validateAlbumCode(code);
-        albumValidator.validateUploadPermission(album, user);
+        albumValidator.validateAlbumParticipant(album, user);
 
         int availableCount = calculateRemainingUploadSlots(album);
 

--- a/src/main/java/com/cheeeese/album/application/validator/AlbumValidator.java
+++ b/src/main/java/com/cheeeese/album/application/validator/AlbumValidator.java
@@ -72,10 +72,6 @@ public class AlbumValidator {
         }
     }
 
-    public void validateUploadPermission(Album album, User user) { // [NEW]
-        validateAlbumParticipant(album, user);
-    }
-
     public void validateDownloadPermission(Album album, User user, List<Photo> photos) {
         validateAlbumParticipant(album, user);
 

--- a/src/main/java/com/cheeeese/album/infrastructure/persistence/AlbumExpirationRedisRepository.java
+++ b/src/main/java/com/cheeeese/album/infrastructure/persistence/AlbumExpirationRedisRepository.java
@@ -16,7 +16,6 @@ import java.util.stream.Collectors;
 public class AlbumExpirationRedisRepository {
 
     private static final String EXPIRATION_ZSET_KEY = "expired:album:zset";
-    private static final ZoneOffset KST_ZONE = ZoneOffset.of("+09:00");
 
     @Qualifier("cacheRedisTemplate")
     private final RedisTemplate<String, Object> cacheRedisTemplate;
@@ -29,7 +28,7 @@ public class AlbumExpirationRedisRepository {
      */
     public void registerAlbum(Long albumId, LocalDateTime expiredAt) {
         // LocalDateTime을 Unix Timestamp (ms)로 변환
-        long expirationMillis = expiredAt.toInstant(KST_ZONE).toEpochMilli();
+        long expirationMillis = expiredAt.toInstant(ZoneOffset.UTC).toEpochMilli();
 
         // ZADD key score member
         cacheRedisTemplate.opsForZSet().add(EXPIRATION_ZSET_KEY, albumId.toString(), (double) expirationMillis);
@@ -41,7 +40,7 @@ public class AlbumExpirationRedisRepository {
      */
     public Set<Long> getExpiredAlbumIds() {
         // 현재 시각의 Unix Timestamp (밀리초)
-        long currentTimestamp = LocalDateTime.now().toInstant(KST_ZONE).toEpochMilli();
+        long currentTimestamp = LocalDateTime.now().toInstant(ZoneOffset.UTC).toEpochMilli();
 
         // ZRANGEBYSCORE key min max: Score가 0부터 현재 시각까지인 모든 Member를 조회
         Set<Object> members = cacheRedisTemplate.opsForZSet().rangeByScore(EXPIRATION_ZSET_KEY, 0, currentTimestamp);

--- a/src/main/java/com/cheeeese/album/infrastructure/persistence/AlbumRepository.java
+++ b/src/main/java/com/cheeeese/album/infrastructure/persistence/AlbumRepository.java
@@ -1,7 +1,9 @@
 package com.cheeeese.album.infrastructure.persistence;
 
 import com.cheeeese.album.domain.Album;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -42,5 +44,9 @@ public interface AlbumRepository extends JpaRepository<Album, Long> {
     @Modifying
     @Query("UPDATE Album a SET a.status = :status WHERE a.id = :id AND a.status <> :status")
     void updateStatus(Long id, Album.AlbumStatus status);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT a FROM Album a WHERE a.id = :id")
+    Album findByIdForUpdate(@Param("id") Long id);
 
 }

--- a/src/main/java/com/cheeeese/photo/application/PhotoCallbackService.java
+++ b/src/main/java/com/cheeeese/photo/application/PhotoCallbackService.java
@@ -1,10 +1,13 @@
 package com.cheeeese.photo.application;
 
+import com.cheeeese.album.infrastructure.persistence.AlbumRepository;
+import com.cheeeese.photo.domain.Photo;
 import com.cheeeese.photo.domain.PhotoStatus;
 import com.cheeeese.photo.dto.request.PhotoCompleteRequest;
 import com.cheeeese.photo.exception.PhotoException;
 import com.cheeeese.photo.exception.code.PhotoErrorCode;
 import com.cheeeese.photo.infrastructure.persistence.PhotoRepository;
+import com.cheeeese.user.application.UserService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,6 +19,8 @@ public class PhotoCallbackService {
 
     private final PhotoRepository photoRepository;
     private final PhotoQueryService photoQueryService;
+    private final AlbumRepository albumRepository;
+    private final UserService userService;
 
     public void markUploadCompleted(PhotoCompleteRequest request) {
         int updated = photoRepository.updateStatusAndUrl(
@@ -28,6 +33,22 @@ public class PhotoCallbackService {
         if (updated == 0) {
             throw new PhotoException(PhotoErrorCode.THUMBNAIL_UPDATE_FAILED);
         }
+
+        Photo photo = photoRepository.findById(request.photoId())
+                .orElseThrow(() -> new PhotoException(PhotoErrorCode.PHOTO_NOT_FOUND));
+
+        int albumUpdated = albumRepository.incrementPhotoCount(photo.getAlbum().getId(), 1);
+        if (albumUpdated == 0) {
+            photoRepository.updateStatusAndUrl(
+                    photo.getId(),
+                    PhotoStatus.COMPLETED,
+                    PhotoStatus.FAILED,
+                    photo.getThumbnailUrl()
+            );
+            throw new PhotoException(PhotoErrorCode.PHOTO_COUNT_INCREMENT_FAILED);
+        }
+
+        userService.incrementPhotoCount(photo.getUser().getId(), 1);
 
         String albumCode = photoRepository.findAlbumCodeByPhotoId(request.photoId());
         if (albumCode != null) {

--- a/src/main/java/com/cheeeese/photo/application/PhotoCleanupScheduler.java
+++ b/src/main/java/com/cheeeese/photo/application/PhotoCleanupScheduler.java
@@ -1,6 +1,5 @@
-package com.cheeeese.photo.dto.request;
+package com.cheeeese.photo.application;
 
-import com.cheeeese.photo.application.PhotoService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;

--- a/src/main/java/com/cheeeese/photo/application/PhotoService.java
+++ b/src/main/java/com/cheeeese/photo/application/PhotoService.java
@@ -2,7 +2,6 @@ package com.cheeeese.photo.application;
 
 import com.cheeeese.album.application.validator.AlbumValidator;
 import com.cheeeese.album.domain.Album;
-import com.cheeeese.album.infrastructure.persistence.AlbumRepository;
 import com.cheeeese.global.util.S3Util;
 import com.cheeeese.photo.application.validator.PhotoValidator;
 import com.cheeeese.photo.domain.Photo;
@@ -22,7 +21,6 @@ import com.cheeeese.photo.infrastructure.mapper.PhotoMapper;
 import com.cheeeese.photo.infrastructure.persistence.PhotoHistoryRepository;
 import com.cheeeese.photo.infrastructure.persistence.PhotoLikesRepository;
 import com.cheeeese.photo.infrastructure.persistence.PhotoRepository;
-import com.cheeeese.user.application.UserService;
 import com.cheeeese.user.domain.User;
 import com.cheeeese.user.infrastructure.persistence.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -41,14 +39,12 @@ import java.util.stream.Collectors;
 @Transactional(readOnly = true)
 public class PhotoService {
 
-    private final UserService userService;
     private final UserRepository userRepository;
     private final PhotoRepository photoRepository;
     private final PhotoLikesRepository photoLikesRepository;
     private final PhotoHistoryRepository photoHistoryRepository;
     private final PhotoValidator photoValidator;
     private final AlbumValidator albumValidator;
-    private final AlbumRepository albumRepository;
     private final PresignedUrlService presignedUrlService;
     private final PhotoQueryService photoQueryService;
 
@@ -243,12 +239,14 @@ public class PhotoService {
             throw new PhotoException(PhotoErrorCode.PHOTO_STATUS_UPDATE_FAILED);
         }
 
-        if (updatedRows > 0) {
-            int decremented = albumRepository.decrementPhotoCount(albumId, updatedRows);
-            if (decremented == 0) {
-                throw new PhotoException(PhotoErrorCode.PHOTO_COUNT_DECREMENT_FAILED);
-            }
-            userService.decrementPhotoCount(user.getId(), updatedRows);
-        }
+        // 업로드 로직 재설계 (선제적으로 count를 올려놓지 않음 -> count 감소 로직 제거)
+        // 혹시 몰라서 나둠
+//        if (updatedRows > 0) {
+//            int decremented = albumRepository.decrementPhotoCount(albumId, updatedRows);
+//            if (decremented == 0) {
+//                throw new PhotoException(PhotoErrorCode.PHOTO_COUNT_DECREMENT_FAILED);
+//            }
+//            userService.decrementPhotoCount(user.getId(), updatedRows);
+//        }
     }
 }

--- a/src/main/java/com/cheeeese/photo/application/PhotoService.java
+++ b/src/main/java/com/cheeeese/photo/application/PhotoService.java
@@ -147,6 +147,16 @@ public class PhotoService {
         photoQueryService.invalidatePhotoCache(photo.getAlbum().getCode());
     }
 
+    @Transactional
+    public void cleanupOldUploadingPhotos() {
+        LocalDateTime threshold = LocalDateTime.now().minusMinutes(30);
+        int updatedCount = photoRepository.updateOldUploadingPhotosStatus(
+                PhotoStatus.FAILED,
+                PhotoStatus.UPLOADING,
+                threshold
+        );
+    }
+
     private Album validateAlbumAndPermission(User user, String albumCode) {
         Album album = albumValidator.validateAlbumCode(albumCode);
         albumValidator.validateUploadPermission(album, user);

--- a/src/main/java/com/cheeeese/photo/application/PhotoService.java
+++ b/src/main/java/com/cheeeese/photo/application/PhotoService.java
@@ -68,16 +68,10 @@ public class PhotoService {
     @Transactional
     public PhotoPresignedUrlResponse createPresignedUrls(User user, PhotoPresignedUrlRequest request) {
         Album album = validateAlbumAndPermission(user, request.albumCode());
-        validateUploadRequest(album, request);
 
-        int uploadCount = request.fileInfos().size();
+        long currentActiveCount = photoRepository.countActivePhotosByAlbumId(album.getId());
 
-        int updatedRows = albumRepository.incrementPhotoCount(album.getId(), uploadCount);
-        if (updatedRows != 1) {
-            throw new PhotoException(PhotoErrorCode.PHOTO_COUNT_INCREMENT_FAILED);
-        }
-
-        userService.incrementPhotoCount(user.getId(), uploadCount);
+        validateUploadRequest(album, request, currentActiveCount);
 
         List<PhotoPresignedUrlResponse.PresignedUrlInfo> presignedUrls = generatePresignedUrls(user, album, request.fileInfos());
 
@@ -163,12 +157,11 @@ public class PhotoService {
         return album;
     }
 
-    private void validateUploadRequest(Album album, PhotoPresignedUrlRequest request) {
-        int currentCount = album.getCurrentPhotoCount();
+    private void validateUploadRequest(Album album, PhotoPresignedUrlRequest request, long currentActiveCount) {
         int maxCount = album.getMaxPhotoCount();
         int requestedCount = request.fileInfos().size();
 
-        photoValidator.validatePhotoCount(currentCount, requestedCount, maxCount);
+        photoValidator.validatePhotoCount(currentActiveCount, requestedCount, maxCount);
         photoValidator.validateFileInfos(request.fileInfos());
     }
 

--- a/src/main/java/com/cheeeese/photo/application/PhotoService.java
+++ b/src/main/java/com/cheeeese/photo/application/PhotoService.java
@@ -2,6 +2,7 @@ package com.cheeeese.photo.application;
 
 import com.cheeeese.album.application.validator.AlbumValidator;
 import com.cheeeese.album.domain.Album;
+import com.cheeeese.album.infrastructure.persistence.AlbumRepository;
 import com.cheeeese.global.util.S3Util;
 import com.cheeeese.photo.application.validator.PhotoValidator;
 import com.cheeeese.photo.domain.Photo;
@@ -30,6 +31,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -41,6 +43,7 @@ public class PhotoService {
 
     private final UserRepository userRepository;
     private final PhotoRepository photoRepository;
+    private final AlbumRepository albumRepository;
     private final PhotoLikesRepository photoLikesRepository;
     private final PhotoHistoryRepository photoHistoryRepository;
     private final PhotoValidator photoValidator;
@@ -63,9 +66,15 @@ public class PhotoService {
 
     @Transactional
     public PhotoPresignedUrlResponse createPresignedUrls(User user, PhotoPresignedUrlRequest request) {
-        Album album = validateAlbumAndPermission(user, request.albumCode());
+        Album album = albumRepository.findByIdForUpdate(
+                albumValidator.validateAlbumCode(request.albumCode()).getId()
+        );
+        albumValidator.validateAlbumParticipant(album, user);
 
-        long currentActiveCount = photoRepository.countActivePhotosByAlbumId(album.getId());
+        long currentActiveCount = photoRepository.countActivePhotosByAlbumId(
+                album.getId(),
+                Arrays.asList(PhotoStatus.UPLOADING, PhotoStatus.COMPLETED)
+        );
 
         validateUploadRequest(album, request, currentActiveCount);
 
@@ -159,7 +168,7 @@ public class PhotoService {
 
     private Album validateAlbumAndPermission(User user, String albumCode) {
         Album album = albumValidator.validateAlbumCode(albumCode);
-        albumValidator.validateUploadPermission(album, user);
+        albumValidator.validateAlbumParticipant(album, user);
         return album;
     }
 

--- a/src/main/java/com/cheeeese/photo/application/validator/PhotoValidator.java
+++ b/src/main/java/com/cheeeese/photo/application/validator/PhotoValidator.java
@@ -50,7 +50,7 @@ public class PhotoValidator {
     /**
      * 앨범 내 업로드 제한 검증
      */
-    public void validatePhotoCount(int currentCount, int uploadCount, int maxPhotoCount) {
+    public void validatePhotoCount(long currentCount, int uploadCount, int maxPhotoCount) {
         if (currentCount + uploadCount > maxPhotoCount) {
             throw new PhotoException(PhotoErrorCode.PHOTO_MAX_COUNT_EXCEEDED);
         }

--- a/src/main/java/com/cheeeese/photo/dto/request/PhotoCleanupScheduler.java
+++ b/src/main/java/com/cheeeese/photo/dto/request/PhotoCleanupScheduler.java
@@ -1,0 +1,18 @@
+package com.cheeeese.photo.dto.request;
+
+import com.cheeeese.photo.application.PhotoService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PhotoCleanupScheduler {
+
+    private final PhotoService photoService;
+
+    @Scheduled(fixedDelay = 600000L)
+    public void runCleanup() {
+        photoService.cleanupOldUploadingPhotos();
+    }
+}

--- a/src/main/java/com/cheeeese/photo/infrastructure/persistence/PhotoRepository.java
+++ b/src/main/java/com/cheeeese/photo/infrastructure/persistence/PhotoRepository.java
@@ -163,4 +163,13 @@ public interface PhotoRepository extends JpaRepository<Photo, Long> {
         WHERE p.id = :photoId
     """)
     String findAlbumCodeByPhotoId(@Param("photoId") Long photoId);
+
+    @Query("""
+        SELECT COUNT(p)
+        FROM Photo p
+        WHERE p.album.id = :albumId
+        AND p.isDeleted = FALSE
+        AND p.status IN ('UPLOADING', 'COMPLETED')
+    """)
+    long countActivePhotosByAlbumId(@Param("albumId") Long albumId);
 }

--- a/src/main/java/com/cheeeese/photo/infrastructure/persistence/PhotoRepository.java
+++ b/src/main/java/com/cheeeese/photo/infrastructure/persistence/PhotoRepository.java
@@ -170,9 +170,9 @@ public interface PhotoRepository extends JpaRepository<Photo, Long> {
         FROM Photo p
         WHERE p.album.id = :albumId
         AND p.isDeleted = FALSE
-        AND p.status IN ('UPLOADING', 'COMPLETED')
+        AND p.status IN :statuses
     """)
-    long countActivePhotosByAlbumId(@Param("albumId") Long albumId);
+    long countActivePhotosByAlbumId(@Param("albumId") Long albumId, @Param("statuses") List<PhotoStatus> statuses);
 
     @Modifying
     @Query("""

--- a/src/main/java/com/cheeeese/photo/infrastructure/persistence/PhotoRepository.java
+++ b/src/main/java/com/cheeeese/photo/infrastructure/persistence/PhotoRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -172,4 +173,17 @@ public interface PhotoRepository extends JpaRepository<Photo, Long> {
         AND p.status IN ('UPLOADING', 'COMPLETED')
     """)
     long countActivePhotosByAlbumId(@Param("albumId") Long albumId);
+
+    @Modifying
+    @Query("""
+        UPDATE Photo p
+        SET p.status = :newStatus
+        WHERE p.status = :expectedStatus
+        AND p.createdAt < :threshold
+    """)
+    int updateOldUploadingPhotosStatus(
+            @Param("newStatus") PhotoStatus newStatus,
+            @Param("expectedStatus") PhotoStatus expectedStatus,
+            @Param("threshold") LocalDateTime threshold
+    );
 }


### PR DESCRIPTION
## 🔗 연관된 이슈
- #66 

## 🚀 변경 유형
- [x] ✨ 기능 추가 (feature)
- [x] 🐛 버그 수정 (fix)
- [ ] 📝 문서 변경 (docs)
- [ ] ♻️ 리팩토링 (refactor)
- [ ] 🧪 테스트 추가 / 수정 (test)
- [ ] ⚙️ 설정 변경 (chore)

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 기존에 선제적으로 album 엔티티의 currentPhotoCount를 늘리는 방식에서 presigned URL 발급 당시의 Photo의 UPLOADING, COMPLETED 상태를 count 하여 발급한다.
- UPLOADING 필드가 계속 남아있으면 presigned URL 발급 count에 영향을 주므로 스케줄러를 도입하여 FAILED 로 상태 변경 추가
- 서버는 UTC 사용하기로 함에 따라 redis에서 KST 제거


## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->

### 📜 리뷰 규칙

Reviewer는 아래 **P5 Rule**을 참고하여 리뷰를 진행합니다.
P5 Rule을 통해 Reviewer는 Reviewee에게 리뷰의 의도를 보다 정확히 전달할 수 있습니다.

> - **P1:** 꼭 반영해주세요 (Comment)
> - **P2:** 적극적으로 고려해주세요 (Comment)
> - **P3:** 웬만하면 반영해 주세요 (Comment)
> - **P4:** 반영해도 좋고 넘어가도 좋습니다 (Approve)
> - **P5:** 그냥 사소한 의견입니다 (Approve)

- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 10분 주기 자동 사진 정리 스케줄러 추가
  * 사진 업로드 완료 시 앨범 및 소유자 사진 개수 자동 반영 및 롤백 보호 추가

* **버그 수정**
  * 사진 개수 검증 안정성 개선(대용량 카운트 처리)
  * 앨범 참가자 기반 권한 검증으로 업로드 권한 판단 일관성 향상
  * 앨범 만료 타임스탬프 처리 시 UTC 기준 통일로 시간 계산 오류 완화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->