### PR TITLE
fix: 앨범 업로드 가능 사진 수 조회 오류

### DIFF
--- a/src/main/java/com/cheeeese/album/application/AlbumService.java
+++ b/src/main/java/com/cheeeese/album/application/AlbumService.java
@@ -154,9 +154,8 @@ public class AlbumService {
         return AlbumMapper.toNewResponse(album, makerInfo, remainingUploadSlots, recentPhotos);
     }
 
-    public UploadAvailableCountResponse getAvailablePhotoCount(User user, String code) {
+    public UploadAvailableCountResponse getAvailablePhotoCount(String code) {
         Album album = albumValidator.validateAlbumCode(code);
-        albumValidator.validateAlbumParticipant(album, user);
 
         int availableCount = calculateRemainingUploadSlots(album);
 

--- a/src/main/java/com/cheeeese/album/presentation/AlbumController.java
+++ b/src/main/java/com/cheeeese/album/presentation/AlbumController.java
@@ -51,14 +51,8 @@ public class AlbumController implements AlbumSwagger {
 
     @Override
     @GetMapping("/{code}/available-count")
-    public CommonResponse<UploadAvailableCountResponse> getAvailableUploadCount(
-            @CurrentUser User user,
-            @PathVariable String code
-    ) {
-        return CommonResponse.success(
-                PHOTO_AVAILABLE_COUNT_FETCH_SUCCESS,
-                albumService.getAvailablePhotoCount(user, code)
-        );
+    public CommonResponse<UploadAvailableCountResponse> getAvailableUploadCount(@PathVariable String code) {
+        return CommonResponse.success(PHOTO_AVAILABLE_COUNT_FETCH_SUCCESS, albumService.getAvailablePhotoCount(code));
     }
 
     @Override

--- a/src/main/java/com/cheeeese/album/presentation/swagger/AlbumSwagger.java
+++ b/src/main/java/com/cheeeese/album/presentation/swagger/AlbumSwagger.java
@@ -187,20 +187,6 @@ public interface AlbumSwagger {
                     description = "업로드 가능 사진 수 조회가 성공적으로 완료되었습니다."
             ),
             @ApiResponse(
-                    responseCode = "403",
-                    description = "참여자가 아닌 사용자의 경우",
-                    content = @Content(
-                            mediaType = "application/json",
-                            schema = @Schema(example = """
-                                {
-                                  "isSuccess": false,
-                                  "code": 403,
-                                  "message": "사용자가 해당 앨범의 참가자가 아닙니다."
-                                }
-                                """)
-                    )
-            ),
-            @ApiResponse(
                     responseCode = "404",
                     description = "존재하지 않거나 유효하지 않은 앨범 코드",
                     content = @Content(
@@ -216,7 +202,6 @@ public interface AlbumSwagger {
             )
     })
     CommonResponse<UploadAvailableCountResponse> getAvailableUploadCount(
-            @CurrentUser User user,
             @PathVariable String code
     );
 

--- a/src/main/java/com/cheeeese/global/config/SecurityConfig.java
+++ b/src/main/java/com/cheeeese/global/config/SecurityConfig.java
@@ -41,7 +41,8 @@ public class SecurityConfig {
             "/v1/album/*/participants",
             "/internal/thumbnail/complete",
             "/v1/user/profile-images",
-            "/v1/album/*/info"
+            "/v1/album/*/info",
+            "/v1/album/*/available-count"
     };
 
     @Bean


### PR DESCRIPTION
## 🔗 연관된 이슈
- #84

## 🚀 변경 유형
- [ ] ✨ 기능 추가 (feature)
- [x] 🐛 버그 수정 (fix)
- [ ] 📝 문서 변경 (docs)
- [ ] ♻️ 리팩토링 (refactor)
- [ ] 🧪 테스트 추가 / 수정 (test)
- [ ] ⚙️ 설정 변경 (chore)

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 앨범 업로드 가능 사진 수를 참여자 X, 로그인 사용자 아니어도 조회 가능하게 수정

## 📸 스크린샷
><img width="530" height="397" alt="image" src="https://github.com/user-attachments/assets/93e652ac-d89b-4904-949a-5679392bfefb" />


## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->

### 📜 리뷰 규칙

Reviewer는 아래 **P5 Rule**을 참고하여 리뷰를 진행합니다.
P5 Rule을 통해 Reviewer는 Reviewee에게 리뷰의 의도를 보다 정확히 전달할 수 있습니다.

> - **P1:** 꼭 반영해주세요 (Comment)
> - **P2:** 적극적으로 고려해주세요 (Comment)
> - **P3:** 웬만하면 반영해 주세요 (Comment)
> - **P4:** 반영해도 좋고 넘어가도 좋습니다 (Approve)
> - **P5:** 그냥 사소한 의견입니다 (Approve)

- 매니악나사빠진것처럼핑핑도라버리겟지

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **변경 사항**
  * 사진 업로드 가능 개수 조회 엔드포인트가 더 이상 사용자 인증을 요구하지 않습니다. 이제 누구나 앨범 코드만으로 업로드 가능한 슬롯 수를 확인할 수 있습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->