### PR TITLE
feat: 서비스 운영 핵심 지표 수집을 위한 비즈니스 로그 추가

### DIFF
--- a/src/main/java/com/cheeeese/album/application/AlbumService.java
+++ b/src/main/java/com/cheeeese/album/application/AlbumService.java
@@ -1,5 +1,6 @@
 package com.cheeeese.album.application;
 
+import com.cheeeese.album.application.logger.AlbumLogger;
 import com.cheeeese.album.application.support.AlbumReader;
 import com.cheeeese.album.application.validator.AlbumValidator;
 import com.cheeeese.album.domain.Album;
@@ -64,11 +65,11 @@ public class AlbumService {
     private final CdnUrlResolver cdnUrlResolver;
     private final AlbumReader albumReader;
 
+    private final AlbumLogger albumLogger;
+
     @Transactional
     public AlbumCreationResponse createAlbum(User user, AlbumCreationRequest request) {
         String code = UuidCreator.getTimeOrdered().toString();
-
-        // long createdThisWeek = countUserAlbumsCreatedThisWeek(user);
 
         albumValidator.validateAlbumCreation(request);
 
@@ -95,6 +96,7 @@ public class AlbumService {
 
         albumExpirationRedisRepository.registerAlbum(album.getId(), expiredAt);
 
+        albumLogger.logAlbumCreated(user.getId(), album.getCode(), request.participant());
         return AlbumMapper.toCreationResponse(album);
     }
 
@@ -125,6 +127,9 @@ public class AlbumService {
         if (existing.isPresent()) {
             UserAlbum userAlbum = existing.get();
 
+            // 재방문 로그
+            albumLogger.logAlbumViewed(currentUser.getId(), album.getCode(), userAlbum.getRole());
+
             if (!userAlbum.isVisible()) {
                 userAlbum.show();
                 return AlbumMapper.toExistingResponse(album, AlbumJoinStatus.REJOINED, makerInfo);
@@ -150,6 +155,9 @@ public class AlbumService {
         List<NewEnterResponse.RecentPhotoResponse> recentPhotos = getRecentPhotosWithUploaderInfo(album.getId());
 
         int remainingUploadSlots = calculateRemainingUploadSlots(album);
+
+        boolean photoExist = album.getCurrentPhotoCount() > 0;
+        albumLogger.logAlbumJoined(currentUser.getId(), album.getCode(), photoExist);
 
         return AlbumMapper.toNewResponse(album, makerInfo, remainingUploadSlots, recentPhotos);
     }
@@ -259,14 +267,6 @@ public class AlbumService {
         int current = album.getCurrentPhotoCount();
         int max = album.getMaxPhotoCount();
         return Math.max(0, max - current);
-    }
-
-    private long countUserAlbumsCreatedThisWeek(User user) {
-        return albumRepository.countByUserAndCreatedAtBetween(
-                user.getId(),
-                LocalDate.now().with(DayOfWeek.MONDAY).atTime(LocalTime.MIN),
-                LocalDate.now().with(DayOfWeek.MONDAY).plusWeeks(1).atTime(LocalTime.now())
-        );
     }
 
     private User getMaker(Long makerId) {

--- a/src/main/java/com/cheeeese/album/application/AlbumService.java
+++ b/src/main/java/com/cheeeese/album/application/AlbumService.java
@@ -71,6 +71,8 @@ public class AlbumService {
     public AlbumCreationResponse createAlbum(User user, AlbumCreationRequest request) {
         String code = UuidCreator.getTimeOrdered().toString();
 
+        // long createdThisWeek = countUserAlbumsCreatedThisWeek(user);
+
         albumValidator.validateAlbumCreation(request);
 
         LocalDateTime expiredAt = LocalDateTime.now().plusDays(7);
@@ -269,7 +271,15 @@ public class AlbumService {
         return Math.max(0, max - current);
     }
 
-    private User getMaker(Long makerId) {
+    private long countUserAlbumsCreatedThisWeek(User user) {
+        return albumRepository.countByUserAndCreatedAtBetween(
+                user.getId(),
+                LocalDate.now().with(DayOfWeek.MONDAY).atTime(LocalTime.MIN),
+                LocalDate.now().with(DayOfWeek.MONDAY).plusWeeks(1).atTime(LocalTime.now())
+        );
+    }
+
+        private User getMaker(Long makerId) {
         return userRepository.findById(makerId)
                 .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
     }

--- a/src/main/java/com/cheeeese/album/application/logger/AlbumLogger.java
+++ b/src/main/java/com/cheeeese/album/application/logger/AlbumLogger.java
@@ -1,0 +1,57 @@
+package com.cheeeese.album.application.logger;
+
+import com.cheeeese.album.domain.type.Role;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Component
+public class AlbumLogger {
+
+    private static final String STAT_PREFIX = "[STAT]";
+
+    /**
+     * [지표 1] 앨범 생성
+     * album_created(user_id, album_code, expected_participant, created_at)
+     */
+    public void logAlbumCreated(Long userId, String albumCode, int expectedParticipant) {
+        try {
+            MDC.put("type", "album");
+            log.info("{} album_created | user_id={} album_code={} expected_participant={} created_at={}",
+                    STAT_PREFIX, userId, albumCode, expectedParticipant, LocalDateTime.now());
+        } finally {
+            MDC.remove("type");
+        }
+    }
+
+    /**
+     * [지표 1, 2] 앨범 입장 (신규)
+     * album_joined(user_id, album_code, is_first_join, photo_exist_on_join, joined_at)
+     */
+    public void logAlbumJoined(Long userId, String albumCode, boolean photoExistOnJoin) {
+        try {
+            MDC.put("type", "album");
+            log.info("{} album_joined | user_id={} album_code={} is_first_join=true photo_exist_on_join={} joined_at={}",
+                    STAT_PREFIX, userId, albumCode, photoExistOnJoin, LocalDateTime.now());
+        } finally {
+            MDC.remove("type");
+        }
+    }
+
+    /**
+     * [지표 2, 4] 앨범 재방문 (조회)
+     * album_view_start(user_id, album_code, role, viewed_at)
+     */
+    public void logAlbumViewed(Long userId, String albumCode, Role role) {
+        try {
+            MDC.put("type", "album");
+            log.info("{} album_view_start | user_id={} album_code={} role={} viewed_at={}",
+                    STAT_PREFIX, userId, albumCode, role, LocalDateTime.now());
+        } finally {
+            MDC.remove("type");
+        }
+    }
+}

--- a/src/main/java/com/cheeeese/album/dto/response/ClosedAlbumSummaryResponse.java
+++ b/src/main/java/com/cheeeese/album/dto/response/ClosedAlbumSummaryResponse.java
@@ -1,6 +1,5 @@
 package com.cheeeese.album.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 

--- a/src/main/java/com/cheeeese/album/dto/response/OpenAlbumSummaryResponse.java
+++ b/src/main/java/com/cheeeese/album/dto/response/OpenAlbumSummaryResponse.java
@@ -1,6 +1,5 @@
 package com.cheeeese.album.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 

--- a/src/main/java/com/cheeeese/auth/application/AuthService.java
+++ b/src/main/java/com/cheeeese/auth/application/AuthService.java
@@ -20,12 +20,14 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
 import java.util.Map;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -45,6 +47,8 @@ public class AuthService {
 
         redisUtil.deleteValue("auth:" + code);
 
+        log.info("[AUTH] Token Exchange Success | user_id={}", user.getId());
+
         return AuthMapper.toExchangeResponse(tokens.get("accessToken"), tokens.get("refreshToken"), user);
     }
 
@@ -62,6 +66,7 @@ public class AuthService {
         savedToken.updateRefreshToken(newRefreshToken);
         refreshTokenRepository.save(savedToken);
 
+        log.info("[AUTH] Token Reissue Success | user_id={}", user.getId());
         return AuthMapper.toReissueResponse(newAccessToken, newRefreshToken);
     }
 
@@ -78,6 +83,8 @@ public class AuthService {
         if (expiration <= 0) {
             expiration = 1000;
         }
+
+        log.info("[AUTH] Logout Success | user_id={}", user.getId());
         tokenBlacklistService.addBlackList(accessToken, "logout", Duration.ofMillis(expiration));
     }
 

--- a/src/main/java/com/cheeeese/cheese4cut/application/Cheese4cutService.java
+++ b/src/main/java/com/cheeeese/cheese4cut/application/Cheese4cutService.java
@@ -26,12 +26,14 @@ import com.cheeeese.photo.infrastructure.persistence.PhotoLikesRepository;
 import com.cheeeese.photo.infrastructure.persistence.PhotoRepository;
 import com.cheeeese.user.domain.User;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -39,6 +41,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -140,6 +143,9 @@ public class Cheese4cutService {
             throw new Cheese4cutException(Cheese4cutErrorCode.INSUFFICIENT_COUNT_FOR_CHEESE4CUT);
 
         cheese4cutRepository.save(Cheese4cutMapper.toEntity(album, orderedPhotos));
+
+        log.info("[Cheese4cut] Cheese4cut Finalized | album_id={} maker_id={} photo_ids={} finalized_at={}",
+                album.getId(), user.getId(), request.photoIds(), LocalDateTime.now());
     }
 
     private List<Photo> getOrderedPhotos(List<Long> photoIds) {

--- a/src/main/java/com/cheeeese/photo/application/PhotoCallbackService.java
+++ b/src/main/java/com/cheeeese/photo/application/PhotoCallbackService.java
@@ -1,6 +1,7 @@
 package com.cheeeese.photo.application;
 
 import com.cheeeese.album.infrastructure.persistence.AlbumRepository;
+import com.cheeeese.photo.application.logger.PhotoLogger;
 import com.cheeeese.photo.domain.Photo;
 import com.cheeeese.photo.domain.PhotoStatus;
 import com.cheeeese.photo.dto.request.PhotoCompleteRequest;
@@ -21,6 +22,8 @@ public class PhotoCallbackService {
     private final PhotoQueryService photoQueryService;
     private final AlbumRepository albumRepository;
     private final UserService userService;
+
+    private final PhotoLogger photoLogger;
 
     public void markUploadCompleted(PhotoCompleteRequest request) {
         int updated = photoRepository.updateStatusAndUrl(
@@ -51,6 +54,9 @@ public class PhotoCallbackService {
         userService.incrementPhotoCount(photo.getUser().getId(), 1);
 
         String albumCode = photoRepository.findAlbumCodeByPhotoId(request.photoId());
+
+        photoLogger.logUploadCompleted(photo.getUser().getId(), albumCode, photo.getId());
+
         if (albumCode != null) {
             photoQueryService.invalidatePhotoCache(albumCode);
         }

--- a/src/main/java/com/cheeeese/photo/application/PhotoService.java
+++ b/src/main/java/com/cheeeese/photo/application/PhotoService.java
@@ -6,6 +6,7 @@ import com.cheeeese.album.domain.Album;
 import com.cheeeese.album.domain.UserAlbum;
 import com.cheeeese.album.infrastructure.persistence.AlbumRepository;
 import com.cheeeese.global.util.S3Util;
+import com.cheeeese.photo.application.logger.PhotoLogger;
 import com.cheeeese.photo.application.support.PhotoReader;
 import com.cheeeese.photo.application.validator.PhotoValidator;
 import com.cheeeese.photo.domain.Photo;
@@ -29,6 +30,7 @@ import com.cheeeese.user.application.UserService;
 import com.cheeeese.user.domain.User;
 import com.cheeeese.user.infrastructure.persistence.UserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
@@ -40,6 +42,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -57,6 +60,8 @@ public class PhotoService {
     private final AlbumReader albumReader;
     private final PresignedUrlService presignedUrlService;
     private final PhotoQueryService photoQueryService;
+
+    private final PhotoLogger photoLogger;
 
     @Value("${ncp.object-storage.bucket}")
     private String bucket;
@@ -87,6 +92,9 @@ public class PhotoService {
 
         List<PhotoPresignedUrlResponse.PresignedUrlInfo> presignedUrls = generatePresignedUrls(user, album, request.fileInfos());
 
+        log.info("[Photo] Photo Upload Request | user_id={} album_code={} file_count={}",
+                user.getId(), request.albumCode(), request.fileInfos().size());
+
         return PhotoMapper.toPresignedUrlResponse(presignedUrls);
     }
 
@@ -116,6 +124,8 @@ public class PhotoService {
                                 () -> photoHistoryRepository.save(PhotoHistoryMapper.toEntity(user, photo))
                         )
                 );
+
+        photoLogger.logDownload(user.getId(), request.code(), request.photoIds());
 
         return PhotoMapper.toPhotoDownloadResponse(presignedUrls);
     }

--- a/src/main/java/com/cheeeese/photo/application/logger/PhotoLogger.java
+++ b/src/main/java/com/cheeeese/photo/application/logger/PhotoLogger.java
@@ -1,0 +1,43 @@
+package com.cheeeese.photo.application.logger;
+
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Component
+public class PhotoLogger {
+
+    private static final String STAT_PREFIX = "[STAT]";
+
+    /**
+     * [지표 2, 3] 사진 업로드 완료
+     * photo_upload_completed(user_id, album_code, photo_id, created_at)
+     */
+    public void logUploadCompleted(Long userId, String albumCode, Long photoId) {
+        try {
+            MDC.put("type", "photo");
+            log.info("{} photo_upload_completed | user_id={} album_code={} photo_id={} created_at={}",
+                    STAT_PREFIX, userId, albumCode, photoId, LocalDateTime.now());
+        } finally {
+            MDC.remove("type");
+        }
+    }
+
+    /**
+     * [지표 3, 5] 사진 다운로드
+     * photo_download_log(user_id, album_code, photo_ids, requested_at)
+     */
+    public void logDownload(Long userId, String albumCode, List<Long> photoIds) {
+        try {
+            MDC.put("type", "photo");
+            log.info("{} photo_download_log | user_id={} album_code={} photo_ids={} requested_at={}",
+                    STAT_PREFIX, userId, albumCode, photoIds, LocalDateTime.now());
+        } finally {
+            MDC.remove("type");
+        }
+    }
+}


### PR DESCRIPTION
## 🔗 연관된 이슈
- #100

## 🚀 변경 유형
- [x] ✨ 기능 추가 (feature)
- [ ] 🐛 버그 수정 (fix)
- [ ] 📝 문서 변경 (docs)
- [ ] ♻️ 리팩토링 (refactor)
- [ ] 🧪 테스트 추가 / 수정 (test)
- [ ] ⚙️ 설정 변경 (chore)

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 기획에서 요구한 서비스 운영 지표 수집을 위한 로그 추가

현재 작업은 두가지 방법으로 진행했습니다.
1. 서비스 운영 지표 분석에 필요한 로그의 경우 `[STAT]` MDC를 추가해서 추후 분석을 용이하도록 설정하였습니다.
2. 이외의 로그에 대해서는 `@Slf4j` 를 사용했습니다.

## 📷 스크린샷
<img width="2032" height="1167" alt="스크린샷 2025-11-27 오전 1 44 37" src="https://github.com/user-attachments/assets/8ee69cc3-56b1-4e7a-b7c2-6d9927ec16a9" />

## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->

### 📜 리뷰 규칙

Reviewer는 아래 **P5 Rule**을 참고하여 리뷰를 진행합니다.
P5 Rule을 통해 Reviewer는 Reviewee에게 리뷰의 의도를 보다 정확히 전달할 수 있습니다.

> - **P1:** 꼭 반영해주세요 (Comment)
> - **P2:** 적극적으로 고려해주세요 (Comment)
> - **P3:** 웬만하면 반영해 주세요 (Comment)
> - **P4:** 반영해도 좋고 넘어가도 좋습니다 (Approve)
> - **P5:** 그냥 사소한 의견입니다 (Approve)

- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 앨범 생성·열람·참여, 인증(토큰 교환·재발급·로그아웃), 사진 업로드 완료·다운로드, Cheese4cut 최종화 관련 이벤트 로깅 추가
  * 별도 로깅 컴포넌트(앨범/사진 통계 로거) 도입으로 로그 형식과 컨텍스트 정비
  * 사용되지 않는 임포트 제거

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->