### PR TITLE
[CEEZ-62] feat: 앨범 만료 시 스토리지 삭제 이벤트 분리 및 Outbox 기반 실패 처리 추가 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,8 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	implementation 'org.springframework.retry:spring-retry'
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
 
 	// swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,6 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'org.springframework.retry:spring-retry'
-	implementation 'org.springframework.boot:spring-boot-starter-aop'
 
 	// swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'

--- a/src/main/java/com/cheeeese/album/application/AlbumExpirationService.java
+++ b/src/main/java/com/cheeeese/album/application/AlbumExpirationService.java
@@ -8,16 +8,17 @@ import com.cheeeese.cheese4cut.domain.Cheese4cut;
 import com.cheeeese.cheese4cut.domain.Cheese4cutPhoto;
 import com.cheeeese.cheese4cut.infrastructure.mapper.Cheese4cutMapper;
 import com.cheeeese.cheese4cut.infrastructure.persistence.Cheese4cutRepository;
-import com.cheeeese.global.util.ObjectStorageDeleteUtil;
 import com.cheeeese.photo.domain.Photo;
 import com.cheeeese.photo.domain.PhotoStatus;
 import com.cheeeese.photo.infrastructure.persistence.PhotoRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -34,7 +35,7 @@ public class AlbumExpirationService {
     private final AlbumRepository albumRepository;
     private final PhotoRepository photoRepository;
     private final Cheese4cutRepository cheese4cutRepository;
-    private final ObjectStorageDeleteUtil objectStorageDeleteUtil;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public void expireAlbum(Long albumId) {
@@ -67,11 +68,7 @@ public class AlbumExpirationService {
         );
 
         if (topPhotoIds.size() < CHEESE4CUT_PHOTO_COUNT) {
-            log.warn(
-                    "[AlbumExpiration] Album id={} does not have enough photos to create cheese4cut (found={})",
-                    albumId,
-                    topPhotoIds.size()
-            );
+            log.warn("[AlbumExpiration] Album id={} has less than 4 photos, skipping cheese4cut creation", albumId);
             return List.of();
         }
 
@@ -81,7 +78,7 @@ public class AlbumExpirationService {
 
         List<Photo> orderedPhotos = topPhotoIds.stream()
                 .map(photoMap::get)
-                .collect(Collectors.toList());
+                .toList();
 
         if (orderedPhotos.stream().anyMatch(Objects::isNull)) {
             log.warn("[AlbumExpiration] Album id={} has missing photos for cheese4cut creation", albumId);
@@ -94,6 +91,10 @@ public class AlbumExpirationService {
         return topPhotoIds;
     }
 
+    /**
+     * 트랜잭션 안에서는 "DB 삭제"만 처리
+     * 스토리지 삭제는 AFTER_COMMIT 이벤트로 넘김
+     */
     private void cleanupPhotosExceptCheese4cut(Album album, List<Long> cheese4cutPhotoIds) {
         List<Photo> photosToDelete = cheese4cutPhotoIds.isEmpty()
                 ? photoRepository.findAllByAlbumId(album.getId())
@@ -102,14 +103,32 @@ public class AlbumExpirationService {
                         cheese4cutPhotoIds
                 );
 
-        if (photosToDelete.isEmpty()) {
-            return;
-        }
-
+        // 이벤트 payload 구성 (스토리지 삭제 대상 URL만 수집)
+        List<AlbumStorageDeleteEvent.PhotoObjectDeleteTarget> photoObjectTargets = new ArrayList<>();
         for (Photo photo : photosToDelete) {
-            objectStorageDeleteUtil.deletePhotoObjects(photo.getImageUrl(), photo.getThumbnailUrl());
+            photoObjectTargets.add(new AlbumStorageDeleteEvent.PhotoObjectDeleteTarget(
+                    photo.getImageUrl(),
+                    photo.getThumbnailUrl(),
+                    true
+            ));
         }
 
-        photoRepository.deleteAll(photosToDelete);
+        // DB 삭제(트랜잭션 내)
+        if (!photosToDelete.isEmpty()) {
+            // photoRepository.deleteAll(photosToDelete);
+            photoRepository.deleteAllInBatch(photosToDelete);
+
+            log.info("[AlbumExpiration] Album id={} deleted photos count={}", album.getId(), photosToDelete.size());
+        }
+
+        // 트랜잭션 커밋 이후 실행될 이벤트 발행
+        if (!photoObjectTargets.isEmpty()) {
+            eventPublisher.publishEvent(new AlbumStorageDeleteEvent(
+                    album.getId(),
+                    photoObjectTargets
+            ));
+            log.info("[AlbumExpiration] Album id={} published storage delete event (photoObjects={})",
+                    album.getId(), photoObjectTargets.size());
+        }
     }
 }

--- a/src/main/java/com/cheeeese/album/application/AlbumStorageDeleteEvent.java
+++ b/src/main/java/com/cheeeese/album/application/AlbumStorageDeleteEvent.java
@@ -1,0 +1,14 @@
+package com.cheeeese.album.application;
+
+import java.util.List;
+
+public record AlbumStorageDeleteEvent(
+        Long albumId,
+        List<PhotoObjectDeleteTarget> photoObjectTargets
+) {
+    public record PhotoObjectDeleteTarget(
+            String imageUrl,
+            String thumbnailUrl,
+            boolean deleteOriginal
+    ) {}
+}

--- a/src/main/java/com/cheeeese/album/application/AlbumStorageDeleteEventHandler.java
+++ b/src/main/java/com/cheeeese/album/application/AlbumStorageDeleteEventHandler.java
@@ -1,7 +1,5 @@
 package com.cheeeese.album.application;
 
-import com.cheeeese.album.domain.StorageDeleteOutbox;
-import com.cheeeese.album.infrastructure.persistence.StorageDeleteOutboxRepository;
 import com.cheeeese.global.util.ObjectStorageDeleteUtil;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -11,6 +9,7 @@ import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Recover;
 import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionalEventListener;
 import org.springframework.transaction.event.TransactionPhase;
 
@@ -20,7 +19,7 @@ import org.springframework.transaction.event.TransactionPhase;
 public class AlbumStorageDeleteEventHandler {
 
     private final ObjectStorageDeleteUtil objectStorageDeleteUtil;
-    private final StorageDeleteOutboxRepository outboxRepository;
+    private final StorageDeleteOutboxWriter outboxWriter;
     private final ObjectMapper objectMapper;
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
@@ -41,7 +40,7 @@ public class AlbumStorageDeleteEventHandler {
             );
         }
 
-        log.info("[AlbumExpiration][StorageDelete] albumId={} async delete completed (photoObjects={})",
+        log.info("[AlbumExpiration][StorageDelete] albumId={} delete completed (photoObjects={})",
                 albumId, event.photoObjectTargets().size());
     }
 
@@ -50,13 +49,14 @@ public class AlbumStorageDeleteEventHandler {
      * - Outbox에 이벤트 payload 저장
      */
     @Recover
+    @Transactional
     public void recover(Exception e, AlbumStorageDeleteEvent event) {
         Long albumId = event.albumId();
 
         String payloadJson = safeToJson(event);
         String reason = (e.getMessage() == null) ? e.getClass().getSimpleName() : e.getMessage();
 
-        outboxRepository.save(StorageDeleteOutbox.of(albumId, payloadJson, reason));
+        outboxWriter.save(albumId, payloadJson, reason);
         log.error("[AlbumExpiration][StorageDelete][OUTBOX] albumId={} saved to outbox. reason={}", albumId, reason, e);
     }
 

--- a/src/main/java/com/cheeeese/album/application/AlbumStorageDeleteEventHandler.java
+++ b/src/main/java/com/cheeeese/album/application/AlbumStorageDeleteEventHandler.java
@@ -1,0 +1,71 @@
+package com.cheeeese.album.application;
+
+import com.cheeeese.album.domain.StorageDeleteOutbox;
+import com.cheeeese.album.infrastructure.persistence.StorageDeleteOutboxRepository;
+import com.cheeeese.global.util.ObjectStorageDeleteUtil;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+import org.springframework.transaction.event.TransactionPhase;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AlbumStorageDeleteEventHandler {
+
+    private final ObjectStorageDeleteUtil objectStorageDeleteUtil;
+    private final StorageDeleteOutboxRepository outboxRepository;
+    private final ObjectMapper objectMapper;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Retryable(
+            retryFor = Exception.class,
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 500, multiplier = 2.0) // 0.5s -> 1s -> 2s
+    )
+    public void handle(AlbumStorageDeleteEvent event) {
+        Long albumId = event.albumId();
+
+        // 1) 삭제된 Photo들의 원본/썸네일 삭제
+        for (AlbumStorageDeleteEvent.PhotoObjectDeleteTarget t : event.photoObjectTargets()) {
+            objectStorageDeleteUtil.deletePhotoObjectsStrict(
+                    t.imageUrl(),
+                    t.thumbnailUrl(),
+                    t.deleteOriginal()
+            );
+        }
+
+        log.info("[AlbumExpiration][StorageDelete] albumId={} async delete completed (photoObjects={})",
+                albumId, event.photoObjectTargets().size());
+    }
+
+    /**
+     * 3회 다 실패한 경우
+     * - Outbox에 이벤트 payload 저장
+     */
+    @Recover
+    public void recover(Exception e, AlbumStorageDeleteEvent event) {
+        Long albumId = event.albumId();
+
+        String payloadJson = safeToJson(event);
+        String reason = (e.getMessage() == null) ? e.getClass().getSimpleName() : e.getMessage();
+
+        outboxRepository.save(StorageDeleteOutbox.of(albumId, payloadJson, reason));
+        log.error("[AlbumExpiration][StorageDelete][OUTBOX] albumId={} saved to outbox. reason={}", albumId, reason, e);
+    }
+
+    private String safeToJson(AlbumStorageDeleteEvent event) {
+        try {
+            return objectMapper.writeValueAsString(event);
+        } catch (JsonProcessingException ex) {
+            // JSON 변환 실패는 payload 최소화해서 남김
+            return "{\"albumId\":" + event.albumId() + ",\"photoObjectTargetsCount\":" + event.photoObjectTargets().size() + "}";
+        }
+    }
+}

--- a/src/main/java/com/cheeeese/album/application/StorageDeleteOutboxWriter.java
+++ b/src/main/java/com/cheeeese/album/application/StorageDeleteOutboxWriter.java
@@ -1,0 +1,20 @@
+package com.cheeeese.album.application;
+
+import com.cheeeese.album.domain.StorageDeleteOutbox;
+import com.cheeeese.album.infrastructure.persistence.StorageDeleteOutboxRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class StorageDeleteOutboxWriter {
+
+    private final StorageDeleteOutboxRepository outboxRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void save(Long albumId, String payloadJson, String reason) {
+        outboxRepository.save(StorageDeleteOutbox.of(albumId, payloadJson, reason));
+    }
+}

--- a/src/main/java/com/cheeeese/album/domain/StorageDeleteOutbox.java
+++ b/src/main/java/com/cheeeese/album/domain/StorageDeleteOutbox.java
@@ -1,0 +1,40 @@
+package com.cheeeese.album.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StorageDeleteOutbox {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long albumId;
+
+    @Lob
+    @Column(nullable = false)
+    private String payloadJson;
+
+    @Column(nullable = false)
+    private String reason;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    private StorageDeleteOutbox(Long albumId, String payloadJson, String reason) {
+        this.albumId = albumId;
+        this.payloadJson = payloadJson;
+        this.reason = reason;
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public static StorageDeleteOutbox of(Long albumId, String payloadJson, String reason) {
+        return new StorageDeleteOutbox(albumId, payloadJson, reason);
+    }
+}

--- a/src/main/java/com/cheeeese/album/domain/StorageDeleteOutbox.java
+++ b/src/main/java/com/cheeeese/album/domain/StorageDeleteOutbox.java
@@ -15,16 +15,17 @@ public class StorageDeleteOutbox {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(name = "album_id", nullable = false)
     private Long albumId;
 
+    @Column(name = "payload_json", nullable = false, columnDefinition = "LONGTEXT")
     @Lob
-    @Column(nullable = false)
     private String payloadJson;
 
     @Column(nullable = false)
     private String reason;
 
-    @Column(nullable = false)
+    @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
 
     private StorageDeleteOutbox(Long albumId, String payloadJson, String reason) {

--- a/src/main/java/com/cheeeese/album/infrastructure/persistence/StorageDeleteOutboxRepository.java
+++ b/src/main/java/com/cheeeese/album/infrastructure/persistence/StorageDeleteOutboxRepository.java
@@ -1,0 +1,7 @@
+package com.cheeeese.album.infrastructure.persistence;
+
+import com.cheeeese.album.domain.StorageDeleteOutbox;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StorageDeleteOutboxRepository extends JpaRepository<StorageDeleteOutbox, Long> {
+}

--- a/src/main/java/com/cheeeese/global/config/RetryConfig.java
+++ b/src/main/java/com/cheeeese/global/config/RetryConfig.java
@@ -1,0 +1,9 @@
+package com.cheeeese.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.annotation.EnableRetry;
+
+@Configuration
+@EnableRetry
+public class RetryConfig {
+}

--- a/src/main/java/com/cheeeese/global/util/ObjectStorageDeleteUtil.java
+++ b/src/main/java/com/cheeeese/global/util/ObjectStorageDeleteUtil.java
@@ -22,16 +22,50 @@ public class ObjectStorageDeleteUtil {
     @Value("${ncp.object-storage.thumbnail-bucket}")
     private String thumbnailBucket;
 
+    // =========================
+    // 실패해도 로그만 남기는 용
+    // =========================
+
     public void deletePhotoObjects(String imageUrl, String thumbnailUrl) {
-        deleteObjectIfPresent(originalBucket, extractObjectKey(imageUrl, "say-cheeeese/"));
+        deletePhotoObjectsInternal(imageUrl, thumbnailUrl, true, false);
+    }
+
+    public void deleteThumbnailVariants(String thumbnailUrl) {
+        deleteThumbnailVariantsInternal(thumbnailUrl, false);
+    }
+
+    // =========================
+    // Strict 메서드: 실패 시 예외 던짐
+    // =========================
+
+    public void deletePhotoObjectsStrict(String imageUrl, String thumbnailUrl, boolean deleteOriginal) {
+        deletePhotoObjectsInternal(imageUrl, thumbnailUrl, deleteOriginal, true);
+    }
+
+    public void deleteThumbnailVariantsStrict(String thumbnailUrl) {
+        deleteThumbnailVariantsInternal(thumbnailUrl, true);
+    }
+
+    private void deletePhotoObjectsInternal(String imageUrl, String thumbnailUrl,
+                                            boolean deleteOriginal, boolean throwOnFailure) {
+        if (deleteOriginal) {
+            deleteObjectIfPresent(originalBucket, extractObjectKey(imageUrl, "say-cheeeese/"), throwOnFailure);
+        }
 
         List<String> thumbnailKeys = buildThumbnailKeys(thumbnailUrl);
         for (String key : thumbnailKeys) {
-            deleteObjectIfPresent(thumbnailBucket, key);
+            deleteObjectIfPresent(thumbnailBucket, key, throwOnFailure);
         }
     }
 
-    private void deleteObjectIfPresent(String bucket, String objectKey) {
+    private void deleteThumbnailVariantsInternal(String thumbnailUrl, boolean throwOnFailure) {
+        List<String> thumbnailKeys = buildThumbnailKeys(thumbnailUrl);
+        for (String key : thumbnailKeys) {
+            deleteObjectIfPresent(thumbnailBucket, key, throwOnFailure);
+        }
+    }
+
+    private void deleteObjectIfPresent(String bucket, String objectKey, boolean throwOnFailure) {
         if (objectKey == null || objectKey.isBlank()) {
             return;
         }
@@ -42,6 +76,12 @@ public class ObjectStorageDeleteUtil {
                     .build());
         } catch (Exception exception) {
             log.warn("[ObjectStorage] Failed to delete object bucket={} key={}", bucket, objectKey, exception);
+
+            if (throwOnFailure) {
+                throw new IllegalStateException(
+                        "Failed to delete object bucket=" + bucket + " key=" + objectKey, exception
+                );
+            }
         }
     }
 


### PR DESCRIPTION
## 🔗 연관된 이슈
- [CEEZ-62](https://saycheeseme.atlassian.net/browse/CEEZ-62)

## 🚀 변경 유형
- [x] ✨ 기능 추가 (feature)
- [x] 🐛 버그 수정 (fix)
- [ ] 📝 문서 변경 (docs)
- [ ] ♻️ 리팩토링 (refactor)
- [ ] 🧪 테스트 추가 / 수정 (test)
- [x] ⚙️ 설정 변경 (chore)

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
#### [CEEZ-35]에서의 작업
- 기존 PR에서 앨범 만료 시 DB 기준 사진 삭제 로직은 이미 구현됨
- 다만 Object Storage 삭제가 서비스 로직에 직접 결합되어 있어
   - 트랜잭션 안정성 부족
   - 외부 I/O 실패 시 복구 불가
   - 운영 중 장애 대응이 어려운 구조였음

#### [CEEZ-62]에 추가한 내용
 1. 스토리지 삭제를 도메인 이벤트로 분리
  - `AlbumExpirationService`에서는
      - DB 삭제만 책임
      - 스토리지 삭제는 `AlbumStorageDeleteEvent` 발행으로 위임


 2. AFTER_COMMIT 이벤트 핸들러 도입
  - 트랜잭션 커밋 이후에만 Object Storage 삭제 수행
  - DB 정합성 보장


 3. Spring Retry 적용
  - 스토리지 삭제 실패 시 최대 3회 재시도


 4. 최종 실패 시 Outbox 저장
  - 재시도 모두 실패할 경우 `storage_delete_outbox` 테이블에 payload 저장
  - 운영 중 수동/배치 재처리 가능하도록 기반 마련


## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->

### 📜 리뷰 규칙

Reviewer는 아래 **P5 Rule**을 참고하여 리뷰를 진행합니다.
P5 Rule을 통해 Reviewer는 Reviewee에게 리뷰의 의도를 보다 정확히 전달할 수 있습니다.

> - **P1:** 꼭 반영해주세요 (Comment)
> - **P2:** 적극적으로 고려해주세요 (Comment)
> - **P3:** 웬만하면 반영해 주세요 (Comment)
> - **P4:** 반영해도 좋고 넘어가도 좋습니다 (Approve)
> - **P5:** 그냥 사소한 의견입니다 (Approve)

- 

[CEEZ-62]: https://saycheeseme.atlassian.net/browse/CEEZ-62?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CEEZ-35]: https://saycheeseme.atlassian.net/browse/CEEZ-35?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CEEZ-62]: https://saycheeseme.atlassian.net/browse/CEEZ-62?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 앨범 만료 시 파일 삭제를 이벤트 기반으로 전환해 트랜잭션 후 처리 및 자동 재시도/대체 경로 적용

* **New Features**
  * 삭제 이벤트 처리기에서 재시도와 실패 시 아웃박스에 페이로드 저장하는 복구 흐름 추가
  * 아웃박스 엔티티 및 저장 서비스 추가

* **Chores**
  * 객체 삭제 유틸에 엄격/비엄격 모드와 오류 처리 옵션 추가
  * 재시도 기능 활성화를 위한 구성 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->