### PR TITLE
[CEEZ-68] fix: 사진 업로드 용량 변경

### DIFF
--- a/src/main/java/com/cheeeese/photo/application/validator/PhotoValidator.java
+++ b/src/main/java/com/cheeeese/photo/application/validator/PhotoValidator.java
@@ -25,7 +25,7 @@ public class PhotoValidator {
 
     private final PhotoRepository photoRepository;
 
-    private static final long MAX_FILE_SIZE = 6 * 1024 * 1024; // 6MB
+    private static final long MAX_FILE_SIZE = 13 * 1024 * 1024; // 13MB
     private static final List<String> ALLOWED_TYPES = List.of("image/jpeg", "image/png", "image/jpg");
 
     /**

--- a/src/main/java/com/cheeeese/photo/exception/code/PhotoErrorCode.java
+++ b/src/main/java/com/cheeeese/photo/exception/code/PhotoErrorCode.java
@@ -11,7 +11,7 @@ public enum PhotoErrorCode implements BaseCode {
 
     // Presigned URL 발급 관련 오류
     PHOTO_MAX_COUNT_EXCEEDED(HttpStatus.BAD_REQUEST, "앨범의 최대 사진 개수를 초과합니다."),
-    PHOTO_FILE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "파일 크기는 6MB를 초과할 수 없습니다."),
+    PHOTO_FILE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "파일 크기는 13MB를 초과할 수 없습니다."),
     PHOTO_INVALID_CONTENT_TYPE(HttpStatus.BAD_REQUEST, "유효한 이미지 파일 형식이 아닙니다."),
     PHOTO_FILE_LIST_EMPTY(HttpStatus.BAD_REQUEST, "업로드할 파일 목록이 비어 있습니다."),
     PHOTO_FILE_NAME_REQUIRED(HttpStatus.BAD_REQUEST, "파일명이 누락되었습니다."),

--- a/src/main/java/com/cheeeese/photo/presentation/swagger/PhotoSwagger.java
+++ b/src/main/java/com/cheeeese/photo/presentation/swagger/PhotoSwagger.java
@@ -32,7 +32,7 @@ public interface PhotoSwagger {
                     ---
                     1. 앨범의 존재 및 만료 여부 확인
                     2. 앨범의 최대 사진 개수 (`maxPhotoCount`) 초과 여부 확인
-                    3. 파일별 크기(6MB), Content-Type(image/jpeg · image/png · image/jpg) 유효성 검증
+                    3. 파일별 크기(13MB), Content-Type(image/jpeg · image/png · image/jpg) 유효성 검증
                     4. 검증 통과 시, DB에 `Photo` 레코드를 `UPLOADING` 상태로 생성
                     5. 클라우드 스토리지 Presigned URL을 발급하여 반환
                     """


### PR DESCRIPTION
## 🔗 연관된 이슈
- [CEEZ-68]

## 🚀 변경 유형
- [ ] ✨ 기능 추가 (feature)
- [x] 🐛 버그 수정 (fix)
- [ ] 📝 문서 변경 (docs)
- [ ] ♻️ 리팩토링 (refactor)
- [ ] 🧪 테스트 추가 / 수정 (test)
- [ ] ⚙️ 설정 변경 (chore)

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 사진 업로드 가능 용량을 6mb에서 13mb로 변경

## 📸 스크린샷
> 13mb 성공
<img width="496" height="500" alt="스크린샷 2026-01-20 오후 7 25 49" src="https://github.com/user-attachments/assets/bae4cde9-ceb5-4cb1-912c-c92522ff2bea" />

> 13mb 초과
<img width="447" height="385" alt="스크린샷 2026-01-20 오후 7 26 17" src="https://github.com/user-attachments/assets/170b022f-0a95-4447-8847-71d0ff59c4a2" />


## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->

### 📜 리뷰 규칙

Reviewer는 아래 **P5 Rule**을 참고하여 리뷰를 진행합니다.
P5 Rule을 통해 Reviewer는 Reviewee에게 리뷰의 의도를 보다 정확히 전달할 수 있습니다.

> - **P1:** 꼭 반영해주세요 (Comment)
> - **P2:** 적극적으로 고려해주세요 (Comment)
> - **P3:** 웬만하면 반영해 주세요 (Comment)
> - **P4:** 반영해도 좋고 넘어가도 좋습니다 (Approve)
> - **P5:** 그냥 사소한 의견입니다 (Approve)

- 

[CEEZ-68]: https://saycheeseme.atlassian.net/browse/CEEZ-68?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 사진 파일의 최대 업로드 크기 제한을 6MB에서 13MB로 증가했습니다. 이제 더 큰 크기의 사진 파일을 업로드할 수 있습니다.

* **Documentation**
  * 사진 업로드 API 문서의 파일 크기 제한 정보를 13MB로 업데이트했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->