### PR TITLE
[CEEZ-77] feat: 사진 상세 조회에 `isMine` 추가

### DIFF
--- a/src/main/java/com/cheeeese/photo/application/PhotoQueryService.java
+++ b/src/main/java/com/cheeeese/photo/application/PhotoQueryService.java
@@ -119,8 +119,11 @@ public class PhotoQueryService {
         boolean canDelete = photo.getUser().getId().equals(user.getId())
                 || photo.getAlbum().getMakerId().equals(user.getId());
 
+        boolean isMine = photo.getUser().getId().equals(user.getId());
+
         return PhotoMapper.toPhotoDetailResponse(
-                photo, profileImage, resolveOriginalUrl, resolveThumbnailUrl, isLiked, isDownloaded, isRecentlyDownloaded, canDelete
+                photo, profileImage, resolveOriginalUrl, resolveThumbnailUrl,
+                isLiked, isDownloaded, isRecentlyDownloaded, canDelete, isMine
         );
     }
 

--- a/src/main/java/com/cheeeese/photo/application/PhotoQueryService.java
+++ b/src/main/java/com/cheeeese/photo/application/PhotoQueryService.java
@@ -42,25 +42,25 @@ public class PhotoQueryService {
     private final RedisCacheUtil redisCacheUtil;
     private final CdnUrlResolver cdnUrlResolver;
 
-    private static final String PHOTO_KEY = "cache:album:%s:photos:sort:%s:page:%d:size:%d:include:%b:version:%d";
+    private static final String PHOTO_KEY = "cache:album:%s:photos:sort:%s:page:%d:size:%d:version:%d";
     private static final String VERSION_KEY = "cache:album:%s:version";
     private static final long PHOTO_CACHE_TTL = 5 * 60L;
 
-    public PhotoPageResponse getPhotoPage(User user, String code, int page, int size, AlbumSorting albumSorting, boolean includeMine) {
+    public PhotoPageResponse getPhotoPage(User user, String code, int page, int size, AlbumSorting albumSorting) {
         Album album = albumValidator.validateAlbumCode(code);
         albumValidator.validateAlbumParticipant(album, user);
 
         String versionKey = String.format(VERSION_KEY, code);
         Long curVersion = Optional.ofNullable(redisCacheUtil.getValue(versionKey)).orElse(0L);
 
-        String photoKey = String.format(PHOTO_KEY, code, albumSorting.getParam(), page, size, includeMine, curVersion);
+        String photoKey = String.format(PHOTO_KEY, code, albumSorting.getParam(), page, size, curVersion);
         PhotoPageResponse cachedList = redisCacheUtil.getObject(photoKey, PhotoPageResponse.class);
 
         // redis에 존재할 경우, db 접근 X + 바로 반환
         if (cachedList != null) {
             return attachUserStatus(user, code, cachedList);
         }
-        PhotoPageResponse responses = getPhotoPageFromDB(code, page, size, albumSorting, includeMine, user.getId());
+        PhotoPageResponse responses = getPhotoPageFromDB(code, page, size, albumSorting);
 
         redisCacheUtil.setValue(photoKey, responses, PHOTO_CACHE_TTL);
 
@@ -127,15 +127,9 @@ public class PhotoQueryService {
         );
     }
 
-    private PhotoPageResponse getPhotoPageFromDB(String code, int page, int size, AlbumSorting albumSorting, boolean includeMine, Long userId) {
+    private PhotoPageResponse getPhotoPageFromDB(String code, int page, int size, AlbumSorting albumSorting) {
         PageRequest pageRequest = PageRequest.of(page, size, getPhotoSortingOption(albumSorting));
-
-        Slice<Photo> photos;
-        if (includeMine) {
-            photos = photoRepository.findAllByAlbumCodeAndStatus(code, PhotoStatus.COMPLETED, pageRequest);
-        } else {
-            photos = photoRepository.findAllByAlbumCodeAndStatusAndUserIdNot(code, PhotoStatus.COMPLETED, userId, pageRequest);
-        }
+        Slice<Photo> photos = photoRepository.findAllByAlbumCodeAndStatus(code, PhotoStatus.COMPLETED, pageRequest);
 
         List<PhotoListResponse> responses = photos.getContent().stream()
                 .map(photo -> {

--- a/src/main/java/com/cheeeese/photo/dto/response/PhotoDetailResponse.java
+++ b/src/main/java/com/cheeeese/photo/dto/response/PhotoDetailResponse.java
@@ -18,7 +18,8 @@ import java.time.LocalDateTime;
                 "isLiked",
                 "isDownloaded",
                 "isRecentlyDownloaded",
-                "canDeleted"
+                "canDelete",
+                "isMine"
         }
 )
 public record PhotoDetailResponse(
@@ -51,6 +52,9 @@ public record PhotoDetailResponse(
 
         @Schema(description = "삭제 가능 여부", example = "false")
         boolean canDelete,
+
+        @Schema(description = "내 사진 여부", example = "false")
+        boolean isMine,
 
         @Schema(description = "촬영 시각", example = "2025-01-13T14:23:45")
         LocalDateTime captureTime,

--- a/src/main/java/com/cheeeese/photo/infrastructure/mapper/PhotoMapper.java
+++ b/src/main/java/com/cheeeese/photo/infrastructure/mapper/PhotoMapper.java
@@ -143,7 +143,8 @@ public class PhotoMapper {
             boolean isLiked,
             boolean isDownloaded,
             boolean isRecentlyDownloaded,
-            boolean canDelete
+            boolean canDelete,
+            boolean isMine
     ) {
         return PhotoDetailResponse.builder()
                 .name(photo.getUser().getName())
@@ -156,6 +157,7 @@ public class PhotoMapper {
                 .isDownloaded(isDownloaded)
                 .isRecentlyDownloaded(isRecentlyDownloaded)
                 .canDelete(canDelete)
+                .isMine(isMine)
                 .captureTime(photo.getCaptureTime())
                 .createdAt(photo.getCreatedAt())
                 .build();

--- a/src/main/java/com/cheeeese/photo/infrastructure/persistence/PhotoRepository.java
+++ b/src/main/java/com/cheeeese/photo/infrastructure/persistence/PhotoRepository.java
@@ -35,22 +35,6 @@ public interface PhotoRepository extends JpaRepository<Photo, Long> {
         SELECT p
         FROM Photo p
         JOIN p.album a
-        WHERE a.code = :code
-        AND p.isDeleted = FALSE
-        AND p.status = :status
-        AND p.user.id != :userId
-    """)
-    Slice<Photo> findAllByAlbumCodeAndStatusAndUserIdNot(
-            @Param("code") String code,
-            @Param("status") PhotoStatus status,
-            @Param("userId") Long userId,
-            Pageable pageable
-    );
-
-    @Query("""
-        SELECT p
-        FROM Photo p
-        JOIN p.album a
         JOIN PhotoLikes pl ON pl.photo = p
         WHERE a.code = :albumCode
         AND p.isDeleted = FALSE

--- a/src/main/java/com/cheeeese/photo/presentation/PhotoQueryController.java
+++ b/src/main/java/com/cheeeese/photo/presentation/PhotoQueryController.java
@@ -28,12 +28,11 @@ public class PhotoQueryController implements PhotoQuerySwagger {
             @PathVariable String code,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size,
-            @RequestParam(defaultValue = "CREATED_AT") AlbumSorting sorting,
-            @RequestParam(defaultValue = "true") boolean includeMine
+            @RequestParam(defaultValue = "CREATED_AT") AlbumSorting sorting
     ) {
         return CommonResponse.success(
                 PHOTO_LIST_GET_SUCCESS,
-                photoQueryService.getPhotoPage(user, code, page, size, sorting, includeMine)
+                photoQueryService.getPhotoPage(user, code, page, size, sorting)
         );
     }
 

--- a/src/main/java/com/cheeeese/photo/presentation/swagger/PhotoQuerySwagger.java
+++ b/src/main/java/com/cheeeese/photo/presentation/swagger/PhotoQuerySwagger.java
@@ -25,8 +25,7 @@ public interface PhotoQuerySwagger {
                     ---
                     `page`: 조회할 페이지 번호 (기본값: 0) \n
                     `size`: 페이지당 사진 개수 (기본값: 20) \n
-                    `sorting`: 정렬 기준 (`CREATED_AT`: 업로드 시간순, `POPULAR`: 띱 많은순, `CAPTURED_AT`: 최근 촬영한 시간순) \n
-                    `includeMine`: 내 사진 포함 여부
+                    `sorting`: 정렬 기준 (`CREATED_AT`: 업로드 시간순, `POPULAR`: 띱 많은순, `CAPTURED_AT`: 최근 촬영한 시간순)
                     """
     )
     @ApiResponses(value = {
@@ -40,8 +39,7 @@ public interface PhotoQuerySwagger {
             @PathVariable String code,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size,
-            @RequestParam(defaultValue = "CREATED_AT") AlbumSorting sorting,
-            @RequestParam(defaultValue = "true") boolean includeMine
+            @RequestParam(defaultValue = "CREATED_AT") AlbumSorting sorting
     );
 
     @Operation(

--- a/src/test/java/com/cheeeese/photo/PhotoQueryPerformanceTest.java
+++ b/src/test/java/com/cheeeese/photo/PhotoQueryPerformanceTest.java
@@ -66,12 +66,12 @@ public class PhotoQueryPerformanceTest {
 
         // DB 조회 (Cache Miss & Save)
         stopWatch.start("DB Query (Cold Start)");
-        photoQueryService.getPhotoPage(testUser, testAlbum.getCode(), 0, 2000, AlbumSorting.CREATED_AT, false);
+        photoQueryService.getPhotoPage(testUser, testAlbum.getCode(), 0, 2000, AlbumSorting.CREATED_AT);
         stopWatch.stop();
 
         // Redis 조회 (Cache Hit)
         stopWatch.start("Redis Cache (Warm Start)");
-        photoQueryService.getPhotoPage(testUser, testAlbum.getCode(), 0, 2000, AlbumSorting.CREATED_AT, false);
+        photoQueryService.getPhotoPage(testUser, testAlbum.getCode(), 0, 2000, AlbumSorting.CREATED_AT);
         stopWatch.stop();
 
         // 결과 출력
@@ -121,12 +121,12 @@ public class PhotoQueryPerformanceTest {
 
         // DB 조회
         stopWatch.start("DB Query (Cold Start)");
-        photoQueryService.getPhotoPage(testUser, testAlbum.getCode(), 0, 2000, AlbumSorting.CREATED_AT, false);
+        photoQueryService.getPhotoPage(testUser, testAlbum.getCode(), 0, 2000, AlbumSorting.CREATED_AT);
         stopWatch.stop();
 
         // Redis 조회
         stopWatch.start("Redis Cache Hit (Warm Start)");
-        photoQueryService.getPhotoPage(testUser, testAlbum.getCode(), 0, 2000, AlbumSorting.CREATED_AT, false);
+        photoQueryService.getPhotoPage(testUser, testAlbum.getCode(), 0, 2000, AlbumSorting.CREATED_AT);
         stopWatch.stop();
 
         System.out.println(stopWatch.prettyPrint());

--- a/src/test/java/com/cheeeese/photo/integration/PhotoQueryServiceIntegrationTest.java
+++ b/src/test/java/com/cheeeese/photo/integration/PhotoQueryServiceIntegrationTest.java
@@ -83,7 +83,7 @@ public class PhotoQueryServiceIntegrationTest {
     void getPhotoList() {
         // when
         PhotoPageResponse page = photoQueryService.getPhotoPage(
-                testUser, testAlbum.getCode(), 0, 20, AlbumSorting.CREATED_AT, false
+                testUser, testAlbum.getCode(), 0, 20, AlbumSorting.CREATED_AT
         );
 
         // then


### PR DESCRIPTION
## 🔗 연관된 이슈
- [CEEZ-77]

## 🚀 변경 유형
- [x] ✨ 기능 추가 (feature)
- [ ] 🐛 버그 수정 (fix)
- [ ] 📝 문서 변경 (docs)
- [ ] ♻️ 리팩토링 (refactor)
- [ ] 🧪 테스트 추가 / 수정 (test)
- [ ] ⚙️ 설정 변경 (chore)

## 📝 작업 내용
<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 사진 상세 조회에 `isMine` 추가

## 📸 스크린샷
> 내 사진
> <img width="735" height="607" alt="image" src="https://github.com/user-attachments/assets/f649fabe-c26a-4bd8-ab64-9dd8fd0c5589" />

> 내 사진 아님
> <img width="598" height="612" alt="image" src="https://github.com/user-attachments/assets/4a93332d-fc48-45bc-acfa-e8df11f68398" />

## 💬 리뷰 요구사항
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요 -->

### 📜 리뷰 규칙

Reviewer는 아래 **P5 Rule**을 참고하여 리뷰를 진행합니다.
P5 Rule을 통해 Reviewer는 Reviewee에게 리뷰의 의도를 보다 정확히 전달할 수 있습니다.

> - **P1:** 꼭 반영해주세요 (Comment)
> - **P2:** 적극적으로 고려해주세요 (Comment)
> - **P3:** 웬만하면 반영해 주세요 (Comment)
> - **P4:** 반영해도 좋고 넘어가도 좋습니다 (Approve)
> - **P5:** 그냥 사소한 의견입니다 (Approve)

[CEEZ-77]: https://saycheeseme.atlassian.net/browse/CEEZ-77?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **변경 사항**
  * 앨범 사진 조회 API에서 `includeMine` 요청 파라미터 제거
  * 사진 응답에 새로운 `isMine` 필드 추가 (해당 사진의 소유 여부 표시)
  * API 응답 구조 개선으로 더 명확한 소유권 정보 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->